### PR TITLE
Moving the module name to add /v2 at the end.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
-module github.com/terraform-providers/terraform-provider-tls
+module github.com/terraform-providers/terraform-provider-tls/v2
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
 	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/terraform-providers/terraform-provider-tls v1.2.0 h1:wcD0InKzNh8fanUYQwim62WCd4toeD9WJnPw/RjBI4o=
 github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvcciqcxEHac4CYj89xI=

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-tls/tls"
+	"github.com/terraform-providers/terraform-provider-tls/tls/v2"
 )
 
 func main() {


### PR DESCRIPTION
Doing this to comply with go module versioning. This is causing an issue
with moving the acme terraform provider over to the latest version of
this provider as it includes this provider as a go module.

This change will require consumers of this provider as a module to
change how they reference this module.

https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher