### PR TITLE
Add PEM-encoded certificate to tls_certificate data source

### DIFF
--- a/internal/provider/data_source_tls_certificate.go
+++ b/internal/provider/data_source_tls_certificate.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha1"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"net/url"
@@ -68,6 +69,10 @@ func dataSourceTlsCertificate() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"pem": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -123,6 +128,7 @@ func parsePeerCertificate(cert *x509.Certificate) map[string]interface{} {
 		"not_before":           cert.NotBefore.Format(time.RFC3339),
 		"not_after":            cert.NotAfter.Format(time.RFC3339),
 		"sha1_fingerprint":     fmt.Sprintf("%x", sha1.Sum(cert.Raw)),
+		"pem":                  string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})),
 	}
 
 	return ret

--- a/internal/provider/data_source_tls_certificate_test.go
+++ b/internal/provider/data_source_tls_certificate_test.go
@@ -42,6 +42,27 @@ data "tls_certificate" "test" {
 					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.not_before", "2019-11-07T15:47:48Z"),
 					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.not_after", "2019-12-17T15:47:48Z"),
 					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.sha1_fingerprint", "5829a9bcc57f317719c5c98d1f48d6c9957cb44e"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.pem", `-----BEGIN CERTIFICATE-----
+MIIDSTCCAjGgAwIBAgIQLYZHhf04h/2jlZsgJbq/1TANBgkqhkiG9w0BAQsFADA0
+MQ0wCwYDVQQHEwRIZXJlMREwDwYDVQQKEwhUZXN0IE9yZzEQMA4GA1UEAxMHUm9v
+dCBDQTAeFw0xOTExMDcxNTQ3NDhaFw0xOTEyMTcxNTQ3NDhaMDQxDTALBgNVBAcT
+BEhlcmUxETAPBgNVBAoTCFRlc3QgT3JnMRAwDgYDVQQDEwdSb290IENBMIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwMNzcNkAoCaIhaEVqPZOt53vws6K
+Owx9SgdRJxFv1t51RdVg3m5NJoQsAFof1giYYP9og2J9gYp6t/ORaWOjcDF1Tt6l
+/vCbQypAwIGHdx5VuJsOy79YoxQVXssNCQZFDl7iuucisuPq9xRSrE84RwTyzU+S
+jUbBeyPEBs3mzekwk0pyndMala/NnkWPgHwEI2lMbvZIXCQqokhhusp85e5cdkgD
+4s2/XyNk9yNTlLaaiA8413G2ABD6cvDbJI5y/Og9A1N+VHN30+qFhNXX7qZqWoiD
+hQQb7CTeqRaNDS3136qPoQZ0w+3iH4Vnl6bCgOrfU1w0k+0v9xs/sEJp+wIDAQAB
+o1cwVTAOBgNVHQ8BAf8EBAMCBaAwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0T
+AQH/BAUwAwEB/zAdBgNVHQ4EFgQUgFGgz37Dv+htdqoCZoI/JV+V3EQwDQYJKoZI
+hvcNAQELBQADggEBALmO85dAooD1+2qhjJuLTZgESnVTS3KJQTqLQypIhyF1an3+
+MMq4h3oYmN5n3dNq+8HKq06XffI6vLqmxo9Mj5CXuos60IydXiASMzRBStkRd+/P
+pJ2u6SJC1+u3HaR/TYLVA5JoZ3JESLzRsM0G75eiEiZy+jQzFaNpuG54ylz4y6jk
+w4sbWtwCeHIbLCU9Ee0lHb0xWrkOJnOPYrq0hlXCCqkml0HjD5jdheoRglJIUabm
+eA3ZUVSXXLsWuPlItoM02+JcMJV82Hfh9w0cYq1Z44eyBJO2EMAkLP0T5GRbWA+R
+0vRPQyF7Oz/Klv3ZhTwS0gzNiTmNPCXvCjZoXhc=
+-----END CERTIFICATE-----
+`),
 
 					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.signature_algorithm", "SHA256-RSA"),
 					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.public_key_algorithm", "RSA"),
@@ -53,6 +74,27 @@ data "tls_certificate" "test" {
 					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.not_before", "2019-11-08T09:01:36Z"),
 					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.not_after", "2019-11-08T19:01:36Z"),
 					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.sha1_fingerprint", "61b65624427d75b61169100836904e44364df817"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.pem", `-----BEGIN CERTIFICATE-----
+MIIDUzCCAjugAwIBAgIRAMhMxtTgTXHTmo6ZU7OafFMwDQYJKoZIhvcNAQELBQAw
+NDENMAsGA1UEBxMESGVyZTERMA8GA1UEChMIVGVzdCBPcmcxEDAOBgNVBAMTB1Jv
+b3QgQ0EwHhcNMTkxMTA4MDkwMTM2WhcNMTkxMTA4MTkwMTM2WjA+MRMwEQYDVQQH
+EwpFdmVyeXdoZXJlMRIwEAYDVQQKEwlDaGlsZCBDby4xEzARBgNVBAMTCkNoaWxk
+IENlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDQTeCu466xxnGr
+CCrl823J4gGnp9AYb0laTP3uB4orXblTFq45ehDnEJXNykT+7acT8IrAjQlVQdl0
+gLjNM6XjGkFQ7xRw5xi041vRrOtUzC1KxVqrcfT4WrKj6zM/MuK3hznc4NvvwdAx
+Mb3Sk46yQ1PrMslsidDvhTAqXkVi3lD1bV/bpnDo3NRCldVpedE1wlR+6thXZN/Y
+MggNuDdv6LDadVGlXgKw5KkEIgenGOzpX1o+GKGo5UWu1xoTHikVwEC1iVuCZax+
+9FnHQO/q7SyF4Lb9d0j6vzrIAjzauGbiAsJya1GhYMF7INxzpSolzk0UYjT5Dxcq
+d3VX1prxAgMBAAGjVjBUMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEF
+BQcDATAMBgNVHRMBAf8EAjAAMB8GA1UdIwQYMBaAFIBRoM9+w7/obXaqAmaCPyVf
+ldxEMA0GCSqGSIb3DQEBCwUAA4IBAQCuXJkT+qD3STmyDlsJOQRLBKaECH+/0mw4
+mn3oMikNfneybjhao+fpwTgFup3KIrdIgbuciHfSTZzWT6mDs9bUdZZLccU6cVRh
+WiX0I1eppjQyOT7PuXDsOsBUMf+et5WuGYrtKsib07q2rHPtTq72iftANtWbznfq
+DsM3TQL4LuEE9V2lU2L2f3kXKrkYzLJj7R4sGck5Fo/E8eeIFm1Z5FCPcia82N+C
+xDsNFvV3r8TsRH60IxFekKddI+ivepa97SvC4r+69MPyxULHNwDtSL+8T4q01LEP
+VKT7dWjBK3K0xxH0SPCtlqRbGalWz4adNNHazN/x7ebK+WB9ReSM
+-----END CERTIFICATE-----
+`),
 				),
 			},
 		},

--- a/website/docs/d/tls_certificate.html.md
+++ b/website/docs/d/tls_certificate.html.md
@@ -49,6 +49,7 @@ The following attributes are exported:
     * `certificates.#.is_ca` - `true` if this certificate is a ca certificate.
     * `certificates.#.issuer` - Who verified and signed the certificate, roughly following
     [RFC2253](https://tools.ietf.org/html/rfc2253).
+    * `certificates.#.pem` - The certificate, PEM-encoded.
     * `certificates.#.public_key_algorithm` - The algorithm used to create the certificate.
     * `certificates.#.serial_number` - Number that uniquely identifies the certificate with the CA's system. The `format`
     function can be used to convert this base 10 number into other bases, such as hex.


### PR DESCRIPTION
Hi,

This pull request adds a `pem` attribute to `certificates` elements of the `tls_certificate` data source, containing the PEM-encoded certificate.

Closes #81 