### PR TITLE
feat: add ED25519 support

### DIFF
--- a/internal/provider/resource_cert_request.go
+++ b/internal/provider/resource_cert_request.go
@@ -5,9 +5,10 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"net"
 	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 const pemCertReqType = "CERTIFICATE REQUEST"

--- a/internal/provider/resource_private_key.go
+++ b/internal/provider/resource_private_key.go
@@ -13,8 +13,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-type keyAlgo func(d *schema.ResourceData) (interface{}, error)
-type keyParser func([]byte) (interface{}, error)
+type (
+	keyAlgo   func(d *schema.ResourceData) (interface{}, error)
+	keyParser func([]byte) (interface{}, error)
+)
 
 var keyAlgos map[string]keyAlgo = map[string]keyAlgo{
 	"RSA": func(d *schema.ResourceData) (interface{}, error) {
@@ -39,7 +41,7 @@ var keyAlgos map[string]keyAlgo = map[string]keyAlgo{
 		return nil, fmt.Errorf("invalid ecdsa_curve; must be P224, P256, P384 or P521")
 	},
 	"ED25519": func(d *schema.ResourceData) (interface{}, error) {
-		priv, _, err := ed25519.GenerateKey(rand.Reader)
+		_, priv, err := ed25519.GenerateKey(rand.Reader)
 		return priv, err
 	},
 }
@@ -139,7 +141,7 @@ func CreatePrivateKey(d *schema.ResourceData, meta interface{}) error {
 			Type:  "EC PRIVATE KEY",
 			Bytes: keyBytes,
 		}
-	case *ed25519.PrivateKey:
+	case ed25519.PrivateKey:
 		keyBytes, err := x509.MarshalPKCS8PrivateKey(k)
 		if err != nil {
 			return fmt.Errorf("error encoding key to PEM: %s", err)
@@ -173,7 +175,7 @@ func publicKey(priv interface{}) interface{} {
 		return &k.PublicKey
 	case *ecdsa.PrivateKey:
 		return &k.PublicKey
-	case *ed25519.PrivateKey:
+	case ed25519.PrivateKey:
 		return k.Public()
 	default:
 		return nil

--- a/internal/provider/resource_private_key.go
+++ b/internal/provider/resource_private_key.go
@@ -24,7 +24,7 @@ var keyAlgos map[string]keyAlgo = map[string]keyAlgo{
 		return rsa.GenerateKey(rand.Reader, rsaBits)
 	},
 	"ECDSA": func(d *schema.ResourceData) (interface{}, error) {
-		var ec elliptic.Curve = nil
+		var ec elliptic.Curve
 		switch d.Get("ecdsa_curve").(string) {
 		case "P224":
 			ec = elliptic.P224()
@@ -34,11 +34,10 @@ var keyAlgos map[string]keyAlgo = map[string]keyAlgo{
 			ec = elliptic.P384()
 		case "P521":
 			ec = elliptic.P521()
+		default:
+			return nil, fmt.Errorf("invalid ecdsa_curve; must be P224, P256, P384 or P521")
 		}
-		if ec != nil {
-			return ecdsa.GenerateKey(ec, rand.Reader)
-		}
-		return nil, fmt.Errorf("invalid ecdsa_curve; must be P224, P256, P384 or P521")
+		return ecdsa.GenerateKey(ec, rand.Reader)
 	},
 	"ED25519": func(d *schema.ResourceData) (interface{}, error) {
 		_, priv, err := ed25519.GenerateKey(rand.Reader)


### PR DESCRIPTION
Nowadays, most recommend using [Ed25519](https://ed25519.cr.yp.to/), so, this little PR adds support for it. Addresses https://github.com/hashicorp/terraform-provider-tls/issues/26 in part.