### PR TITLE
Fix package to follow correct Go version guidelines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/terraform-providers/terraform-provider-tls
+module github.com/terraform-providers/terraform-provider-tls/v3
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/terraform-providers/terraform-provider-tls/internal/provider"
+	"github.com/terraform-providers/terraform-provider-tls/v3/internal/provider"
 )
 
 func main() {


### PR DESCRIPTION
The current package name
(github.com/terraform-providers/terraform-provider-tls) lacks a version
path and as such cannot be imported into other projects.

I currently depend on this provider in
github.com/vancluever/terraform-provider-acme, and this is effectively
keeping me from modernizing the provider due to a lack of ability to
upgrade testing dependencies.