### PR TITLE
Allow tls_public_key to retrieve public keys from SSH servers

### DIFF
--- a/internal/provider/data_source_public_key.go
+++ b/internal/provider/data_source_public_key.go
@@ -13,9 +13,17 @@ func dataSourcePublicKey() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"private_key_pem": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Required:    false,
+				Optional:    true,
 				Sensitive:   true,
-				Description: "PEM formatted string to use as the private key",
+				Description: "PEM formatted string to use as the private key (provide this or ssh_server)",
+			},
+			"ssh_server_uri": {
+				Type:        schema.TypeString,
+				Required:    false,
+				Optional:    true,
+				Sensitive:   false,
+				Description: "SSH server from which to retrieve the public key (provide this or private_key_pem)",
 			},
 			"algorithm": {
 				Type:        schema.TypeString,
@@ -39,39 +47,45 @@ func dataSourcePublicKey() *schema.Resource {
 }
 
 func dataSourcePublicKeyRead(d *schema.ResourceData, meta interface{}) error {
-	// Read private key
-	bytes := []byte("")
 	if v, ok := d.GetOk("private_key_pem"); ok {
+		// Read private key
+		bytes := []byte("")
 		bytes = []byte(v.(string))
-	} else {
-		return fmt.Errorf("invalid private key %#v", v)
-	}
-	// decode PEM encoding to ANS.1 PKCS1 DER
-	keyPemBlock, _ := pem.Decode(bytes)
+		// decode PEM encoding to ANS.1 PKCS1 DER
+		keyPemBlock, _ := pem.Decode(bytes)
 
-	if keyPemBlock == nil || (keyPemBlock.Type != "RSA PRIVATE KEY" && keyPemBlock.Type != "EC PRIVATE KEY") {
-		typ := "unknown"
+		if keyPemBlock == nil || (keyPemBlock.Type != "RSA PRIVATE KEY" && keyPemBlock.Type != "EC PRIVATE KEY") {
+			typ := "unknown"
 
-		if keyPemBlock != nil {
-			typ = keyPemBlock.Type
+			if keyPemBlock != nil {
+				typ = keyPemBlock.Type
+			}
+
+			return fmt.Errorf("failed to decode PEM block containing private key of type %#v", typ)
 		}
 
-		return fmt.Errorf("failed to decode PEM block containing private key of type %#v", typ)
-	}
+		keyAlgo := ""
+		switch keyPemBlock.Type {
+		case "RSA PRIVATE KEY":
+			keyAlgo = "RSA"
+		case "EC PRIVATE KEY":
+			keyAlgo = "ECDSA"
+		}
+		d.Set("algorithm", keyAlgo)
+		// Converts a private key from its ASN.1 PKCS#1 DER encoded form
+		key, err := parsePrivateKey(d, "private_key_pem", "algorithm")
+		if err != nil {
+			return fmt.Errorf("error converting key to algo: %s - %s", keyAlgo, err)
+		}
 
-	keyAlgo := ""
-	switch keyPemBlock.Type {
-	case "RSA PRIVATE KEY":
-		keyAlgo = "RSA"
-	case "EC PRIVATE KEY":
-		keyAlgo = "ECDSA"
+		return readPublicKey(d, key)
+	} else {
+		// Retrieve public key from ssh server
+		if v, ok := d.GetOk("ssh_server_uri"); ok {
+			d.Set("algorithm", "RSA")
+			return readSSHServerPublicKey(d, v.(string))
+		} else {
+			return fmt.Errorf("Neither private_key_pem nor ssh_server_uri provided")
+		}
 	}
-	d.Set("algorithm", keyAlgo)
-	// Converts a private key from its ASN.1 PKCS#1 DER encoded form
-	key, err := parsePrivateKey(d, "private_key_pem", "algorithm")
-	if err != nil {
-		return fmt.Errorf("error converting key to algo: %s - %s", keyAlgo, err)
-	}
-
-	return readPublicKey(d, key)
 }


### PR DESCRIPTION
This allows SSH authorized_key files to be populated based on an existing remote server's public key.

This still needs some DRY editing and test updates, but opening as a PR early to get my proof of concept code in place for some feedback on attribute naming, etc, first.

This allows the data source to be used like:

```
data "tls_public_key" "codecommit" {
  ssh_server_uri = "git-codecommit.${var.region}.amazonaws.com"
}

...

  data = {
    known_hosts = "git-codecommit.${var.region}.amazonaws.com ${data.tls_public_key.codecommit.public_key_openssh}"
  }

...
```