### PR TITLE
Add tls ssh key scan data source

### DIFF
--- a/internal/provider/data_source_ssh_key_scan.go
+++ b/internal/provider/data_source_ssh_key_scan.go
@@ -1,0 +1,71 @@
+package provider
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceSshKeyScan() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceSshKeyScanRead,
+		Schema: map[string]*schema.Schema{
+			"host": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Host to ssh key scan.",
+			},
+			"port": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     22,
+				Description: "Port to key scan",
+			},
+			"public_host_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Result of ssh key scan.",
+			},
+		},
+	}
+}
+
+func dataSourceSshKeyScanRead(d *schema.ResourceData, meta interface{}) error {
+	host := d.Get("host").(string)
+	port := d.Get("port").(int)
+
+	hostKeyCh := make(chan string, 1)
+	hostKeyError := errors.New("ignoring host key verification")
+	hostKeyCallback := func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		keyStr := base64.StdEncoding.EncodeToString([]byte(key.Marshal()))
+		hostKeyCh <- fmt.Sprintf("%s %s", key.Type(), keyStr)
+		return hostKeyError
+	}
+
+	config := &ssh.ClientConfig{
+		HostKeyCallback: hostKeyCallback,
+		Timeout:         5 * time.Second,
+	}
+	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%v", host, port), config)
+	if err != nil && !strings.Contains(err.Error(), hostKeyError.Error()) {
+		return err
+	}
+
+	// Authentication errors will cause client to be nil
+	if client != nil {
+		client.Close()
+	}
+	hostKey := <-hostKeyCh
+
+	d.Set("public_host_key", fmt.Sprintf("%s %s", host, hostKey))
+	d.SetId(time.Now().UTC().String())
+
+	return nil
+}

--- a/internal/provider/data_source_ssh_key_scan_test.go
+++ b/internal/provider/data_source_ssh_key_scan_test.go
@@ -1,0 +1,25 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccSshKeyScan_dataSource(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers: testProviders,
+
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "tls_ssh_key_scan" "test" {
+  host = "github.com"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.tls_ssh_key_scan.test", "public_host_key", "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -18,8 +18,9 @@ func New() *schema.Provider {
 			"tls_cert_request":        resourceCertRequest(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"tls_public_key":  dataSourcePublicKey(),
-			"tls_certificate": dataSourceTlsCertificate(),
+			"tls_public_key":   dataSourcePublicKey(),
+			"tls_certificate":  dataSourceTlsCertificate(),
+			"tls_ssh_key_scan": dataSourceSshKeyScan(),
 		},
 	}
 }


### PR DESCRIPTION
Adds a new datasource `tls_ssh_key_scan` which allows for dynamic known hosts in Terraform.