### PR TITLE
Support local tls certificate file as input for tls_certificate data source 

### DIFF
--- a/internal/provider/data_source_tls_certificate_test.go
+++ b/internal/provider/data_source_tls_certificate_test.go
@@ -25,10 +25,47 @@ func TestAccTlsCertificate_dataSource(t *testing.T) {
 
 				Config: fmt.Sprintf(`
 data "tls_certificate" "test" {
-  url = "https://%s"
-  verify_chain = false
+ input = "https://%s"
+ verify_chain = false
+ type = "remote"
 }
 `, host),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.#", "2"),
+
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.signature_algorithm", "SHA256-RSA"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.public_key_algorithm", "RSA"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.serial_number", "60512478256160404377639062250777657301"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.is_ca", "true"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.version", "3"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.issuer", "CN=Root CA,O=Test Org,L=Here"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.subject", "CN=Root CA,O=Test Org,L=Here"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.not_before", "2019-11-07T15:47:48Z"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.not_after", "2019-12-17T15:47:48Z"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.sha1_fingerprint", "5829a9bcc57f317719c5c98d1f48d6c9957cb44e"),
+
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.signature_algorithm", "SHA256-RSA"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.public_key_algorithm", "RSA"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.serial_number", "266244246501122064554217434340898012243"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.is_ca", "false"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.version", "3"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.issuer", "CN=Root CA,O=Test Org,L=Here"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.subject", "CN=Child Cert,O=Child Co.,L=Everywhere"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.not_before", "2019-11-08T09:01:36Z"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.not_after", "2019-11-08T19:01:36Z"),
+					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.sha1_fingerprint", "61b65624427d75b61169100836904e44364df817"),
+				),
+			},
+
+			{
+
+				Config: `
+data "tls_certificate" "test" {
+ input =  file("testdata/tls_certs/public.pem")
+ verify_chain = false
+ type = "local"
+}
+`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.tls_certificate.test", "certificates.#", "2"),
 

--- a/website/docs/d/tls_certificate.html.md
+++ b/website/docs/d/tls_certificate.html.md
@@ -9,7 +9,7 @@ description: |-
 # Data Source: tls_certificate
 
 Reads the information of TLS certificate (SHA1 fingerprint, serial number, issuer, expiration date etc). Certificate can
-reside locally or remote i.e. protecting HTTPS website
+reside locally or remotely i.e. protecting HTTPS website
 
 ## Example Usage
 

--- a/website/docs/d/tls_certificate.html.md
+++ b/website/docs/d/tls_certificate.html.md
@@ -9,7 +9,7 @@ description: |-
 # Data Source: tls_certificate
 
 Use this data source to get information, such as SHA1 fingerprint or serial number, about the TLS certificates that
-protect an HTTPS website. Note that the certificate chain isn't verified.
+protect an HTTPS website. Information about local TLS certificate could also be found. Note that the certificate chain isn't verified.
 
 ## Example Usage
 
@@ -19,7 +19,8 @@ resource "aws_eks_cluster" "example" {
 }
 
 data "tls_certificate" "example" {
-  url = "${aws_eks_cluster.example.identity.0.oidc.0.issuer}"
+  input = "${aws_eks_cluster.example.identity.0.oidc.0.issuer}"
+  type  = "remote"
 }
 
 resource "aws_iam_openid_connect_provider" "example" {
@@ -33,7 +34,8 @@ resource "aws_iam_openid_connect_provider" "example" {
 
 The following arguments are supported:
 
-* `url` - (Required) The URL of the website to get the certificates from.
+* `input` - (Required) The input for the data source. It can either be the URL of the website to get the certificates from or string containing the content of the PEM file.
+* `type` - (Required) The type of the input. Must be either `local` or `remote`.
 * `verify_chain` - (Optional) Whether to verify the certificate chain while parsing it or not
 
 

--- a/website/docs/d/tls_certificate.html.md
+++ b/website/docs/d/tls_certificate.html.md
@@ -8,8 +8,8 @@ description: |-
 
 # Data Source: tls_certificate
 
-Use this data source to get information, such as SHA1 fingerprint or serial number, about the TLS certificates that
-protect an HTTPS website. Information about local TLS certificate could also be found. Note that the certificate chain isn't verified.
+Reads the information of TLS certificate (SHA1 fingerprint, serial number, issuer, expiration date etc). Certificate can
+reside locally or remote i.e. protecting HTTPS website
 
 ## Example Usage
 


### PR DESCRIPTION
Hi team,

I would like to propose a new feature to support local tls file as an input for `tls_certificate` data source.

Example:

For local file
```
data "tls_certificate" "test" {
   input  =  file("testdata/tls_certs/public.pem")
   type   = "local"
```
For remote file (sitting behind and HTTPS endpoint)
```
data "tls_certificate" "test" {
 input = "https://your-target-website.com"
 type  = "remote"

```

This will serve as an extension for  #62  solve #4  where the author wants to read from file `${file('path/to/cert.pem')}` for example