### PR TITLE
fix unit test for resource_private_key_test

### DIFF
--- a/internal/provider/resource_private_key_test.go
+++ b/internal/provider/resource_private_key_test.go
@@ -19,7 +19,8 @@ func TestPrivateKeyRSA(t *testing.T) {
                         algorithm = "RSA"
                     }
                     output "private_key_pem" {
-                        value = "${tls_private_key.test.private_key_pem}"
+                        value     = "${tls_private_key.test.private_key_pem}"
+                        sensitive = true
                     }
                     output "public_key_pem" {
                         value = "${tls_private_key.test.public_key_pem}"
@@ -79,10 +80,11 @@ func TestPrivateKeyRSA(t *testing.T) {
 				Config: `
                     resource "tls_private_key" "test" {
                         algorithm = "RSA"
-                        rsa_bits = 4096
+                        rsa_bits  = 4096
                     }
                     output "key_pem" {
-                        value = "${tls_private_key.test.private_key_pem}"
+                        value     = "${tls_private_key.test.private_key_pem}"
+                        sensitive = true
                     }
                 `,
 				Check: func(s *terraform.State) error {
@@ -114,7 +116,8 @@ func TestPrivateKeyECDSA(t *testing.T) {
                         algorithm = "ECDSA"
                     }
                     output "private_key_pem" {
-                        value = "${tls_private_key.test.private_key_pem}"
+                        value     = "${tls_private_key.test.private_key_pem}"
+                        sensitive = true
                     }
                     output "public_key_pem" {
                         value = "${tls_private_key.test.public_key_pem}"
@@ -163,11 +166,12 @@ func TestPrivateKeyECDSA(t *testing.T) {
 			{
 				Config: `
                     resource "tls_private_key" "test" {
-                        algorithm = "ECDSA"
+                        algorithm   = "ECDSA"
                         ecdsa_curve = "P256"
                     }
                     output "private_key_pem" {
-                        value = "${tls_private_key.test.private_key_pem}"
+                        value     = "${tls_private_key.test.private_key_pem}"
+                        sensitive = true
                     }
                     output "public_key_pem" {
                         value = "${tls_private_key.test.public_key_pem}"


### PR DESCRIPTION
Hi team,

I would like to put forward this MR to fix the error when running `make test`. 

```
❯ make test
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./...) || exit 1
echo $(go list ./...) | \
        xargs -t -n4 go test  -timeout=120s -parallel=4
go test '-timeout=120s' '-parallel=4' github.com/terraform-providers/terraform-provider-tls github.com/terraform-providers/terraform-provider-tls/internal/provider 
?       github.com/terraform-providers/terraform-provider-tls   [no test files]
--- FAIL: TestPrivateKeyRSA (0.25s)
    resource_private_key_test.go:13: Step 1/2 error: Error running pre-apply refresh: exit status 1
        
        Error: Output refers to sensitive values
        
          on terraform_plugin_test.tf line 5:
           5:                     output "private_key_pem" {
        
        To reduce the risk of accidentally exporting sensitive data that was intended
        to be only internal, Terraform requires that any root module output
        containing sensitive data be explicitly marked as sensitive, to confirm your
        intent.
        
        If you do intend to export this data, annotate the output value as sensitive
        by adding the following argument:
            sensitive = true
--- FAIL: TestPrivateKeyECDSA (0.26s)
    resource_private_key_test.go:108: Step 1/2 error: Error running pre-apply refresh: exit status 1
        
        Error: Output refers to sensitive values
        
          on terraform_plugin_test.tf line 5:
           5:                     output "private_key_pem" {
        
        To reduce the risk of accidentally exporting sensitive data that was intended
        to be only internal, Terraform requires that any root module output
        containing sensitive data be explicitly marked as sensitive, to confirm your
        intent.
        
        If you do intend to export this data, annotate the output value as sensitive
        by adding the following argument:
            sensitive = true
FAIL
FAIL    github.com/terraform-providers/terraform-provider-tls/internal/provider 22.610s
FAIL
make: *** [GNUmakefile:12: test] Error 123

```