### PR TITLE
fixes typo in `certficate`

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 The TLS provider provides utilities for working with *Transport Layer Security*
 keys and certificates. It provides resources that
-allow private keys, certificates and certficate requests to be
+allow private keys, certificates and certificate requests to be
 created as part of a Terraform deployment.
 
 Another name for Transport Layer Security is *Secure Sockets Layer*,


### PR DESCRIPTION
Hello maintainers 👋🏼 

Came across a typo in the website and the `About` section on GitHub. This PR solves the docs typo, but doesn't solve the `About` part.

In the repository's [main page](https://github.com/hashicorp/terraform-provider-tls) in the right sidebar, the following text:

> It provides resources that allow private keys, certificates and certficate requests to be created as part of a Terraform deployment.

Needs "certficate" updated to "certificate".

Hope this helps!
