### PR TITLE
QoL: Enabling Golang static code analysis with `golangci-lint`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run (acceptance) tests
+name: Test
 
 on:
   pull_request:
@@ -31,13 +31,10 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
-    - name: Go fmt
-      run: |
-        make fmt
-
-    - name: Go vet
-      run: |
-        make vet
+    - name: Linting (golangci-lint)
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: latest
 
     - name: Compile
       run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+linters:
+  # Default linters enabled
+  # See: https://golangci-lint.run/usage/linters/#enabled-by-default-linters
+
+  # Additional linters enabled
+  enable:
+    - durationcheck
+    - exportloopref
+    - godot
+    - gofmt
+    - makezero
+    - misspell
+    - nilerr
+    - predeclared
+#    - tenv # TODO: Enable when upgrading Go 1.16 to 1.17
+    - unconvert
+    - unparam

--- a/internal/openssh/lib_test.go
+++ b/internal/openssh/lib_test.go
@@ -26,7 +26,7 @@ func TestOpenSSHFormat_MarshalAndUnmarshal_RSA(t *testing.T) {
 	pemOpenSSHPrvKeyBytes := pem.EncodeToMemory(pemOpenSSHPrvKey)
 
 	// Parse it back into an RSA private key
-	rawPrivateKey, err := ssh.ParseRawPrivateKey(pemOpenSSHPrvKeyBytes)
+	rawPrivateKey, _ := ssh.ParseRawPrivateKey(pemOpenSSHPrvKeyBytes)
 	rsaParsed, ok := rawPrivateKey.(*rsa.PrivateKey)
 	if !ok {
 		t.Errorf("Failed to type assert RSA private key: %v", rawPrivateKey)
@@ -58,7 +58,7 @@ func TestOpenSSHFormat_MarshalAndUnmarshal_ECDSA(t *testing.T) {
 	pemOpenSSHPrvKeyBytes := pem.EncodeToMemory(pemOpenSSHPrvKey)
 
 	// Parse it back into an ECDSA private key
-	rawPrivateKey, err := ssh.ParseRawPrivateKey(pemOpenSSHPrvKeyBytes)
+	rawPrivateKey, _ := ssh.ParseRawPrivateKey(pemOpenSSHPrvKeyBytes)
 	ecdsaParsed, ok := rawPrivateKey.(*ecdsa.PrivateKey)
 	if !ok {
 		t.Errorf("Failed to type assert ECDSA private key: %v", rawPrivateKey)
@@ -85,7 +85,7 @@ func TestOpenSSHFormat_MarshalAndUnmarshal_ED25519(t *testing.T) {
 	pemOpenSSHPrvKeyBytes := pem.EncodeToMemory(pemOpenSSHPrvKey)
 
 	// Parse it back into an ED25519 private key
-	rawPrivateKey, err := ssh.ParseRawPrivateKey(pemOpenSSHPrvKeyBytes)
+	rawPrivateKey, _ := ssh.ParseRawPrivateKey(pemOpenSSHPrvKeyBytes)
 	ed25519Parsed, ok := rawPrivateKey.(*ed25519.PrivateKey)
 	if !ok {
 		t.Errorf("Failed to type assert ED25519 private key: %v", rawPrivateKey)

--- a/internal/provider/data_source_public_key.go
+++ b/internal/provider/data_source_public_key.go
@@ -53,7 +53,7 @@ func dataSourcePublicKey() *schema.Resource {
 
 func dataSourcePublicKeyRead(d *schema.ResourceData, _ interface{}) error {
 	// Read private key
-	bytes := []byte("")
+	var bytes []byte
 	if v, ok := d.GetOk("private_key_pem"); ok {
 		bytes = []byte(v.(string))
 	} else {
@@ -79,7 +79,10 @@ func dataSourcePublicKeyRead(d *schema.ResourceData, _ interface{}) error {
 	case "EC PRIVATE KEY":
 		keyAlgo = "ECDSA"
 	}
-	d.Set("algorithm", keyAlgo)
+	if err := d.Set("algorithm", keyAlgo); err != nil {
+		return fmt.Errorf("error setting value on key 'algorithm': %s", err)
+	}
+
 	// Converts a private key from its ASN.1 PKCS#1 DER encoded form
 	key, err := parsePrivateKey(d, "private_key_pem", "algorithm")
 	if err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -32,7 +32,7 @@ func hashForState(value string) string {
 	return hex.EncodeToString(hash[:])
 }
 
-func nameFromResourceData(nameMap map[string]interface{}) (*pkix.Name, error) {
+func nameFromResourceData(nameMap map[string]interface{}) *pkix.Name {
 	result := &pkix.Name{}
 
 	if value := nameMap["common_name"]; value != "" {
@@ -66,7 +66,7 @@ func nameFromResourceData(nameMap map[string]interface{}) (*pkix.Name, error) {
 		result.SerialNumber = value.(string)
 	}
 
-	return result, nil
+	return result
 }
 
 var nameSchema *schema.Resource = &schema.Resource{

--- a/internal/provider/resource_cert_request.go
+++ b/internal/provider/resource_cert_request.go
@@ -97,10 +97,7 @@ func CreateCertRequest(d *schema.ResourceData, meta interface{}) error {
 	if !ok {
 		return fmt.Errorf("subject block cannot be empty")
 	}
-	subject, err := nameFromResourceData(subjectConf)
-	if err != nil {
-		return fmt.Errorf("invalid subject block: %s", err)
-	}
+	subject := nameFromResourceData(subjectConf)
 
 	certReq := x509.CertificateRequest{
 		Subject: *subject,
@@ -134,7 +131,10 @@ func CreateCertRequest(d *schema.ResourceData, meta interface{}) error {
 	certReqPem := string(pem.EncodeToMemory(&pem.Block{Type: pemCertReqType, Bytes: certReqBytes}))
 
 	d.SetId(hashForState(string(certReqBytes)))
-	d.Set("cert_request_pem", certReqPem)
+
+	if err := d.Set("cert_request_pem", certReqPem); err != nil {
+		return fmt.Errorf("error setting value on key 'cert_request_pem': %s", err)
+	}
 
 	return nil
 }

--- a/internal/provider/resource_cert_request.go
+++ b/internal/provider/resource_cert_request.go
@@ -126,7 +126,7 @@ func CreateCertRequest(d *schema.ResourceData, meta interface{}) error {
 
 	certReqBytes, err := x509.CreateCertificateRequest(rand.Reader, &certReq, key)
 	if err != nil {
-		return fmt.Errorf("Error creating certificate request: %s", err)
+		return fmt.Errorf("error creating certificate request: %s", err)
 	}
 	certReqPem := string(pem.EncodeToMemory(&pem.Block{Type: pemCertReqType, Bytes: certReqBytes}))
 

--- a/internal/provider/resource_self_signed_cert.go
+++ b/internal/provider/resource_self_signed_cert.go
@@ -91,10 +91,7 @@ func CreateSelfSignedCert(d *schema.ResourceData, meta interface{}) error {
 	if !ok {
 		return fmt.Errorf("subject block cannot be empty")
 	}
-	subject, err := nameFromResourceData(subjectConf)
-	if err != nil {
-		return fmt.Errorf("invalid subject block: %s", err)
-	}
+	subject := nameFromResourceData(subjectConf)
 
 	cert := x509.Certificate{
 		Subject:               *subject,

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -1,6 +1,6 @@
 package provider
 
-// Algorithm represents a type of private key algorithm
+// Algorithm represents a type of private key algorithm.
 type Algorithm string
 
 const (
@@ -9,7 +9,7 @@ const (
 	ED25519 Algorithm = "ED25519"
 )
 
-// SupportedAlgorithms returns a slice of Algorithm currently supported by this provider
+// SupportedAlgorithms returns a slice of Algorithm currently supported by this provider.
 func SupportedAlgorithms() []Algorithm {
 	return []Algorithm{
 		RSA,
@@ -18,7 +18,7 @@ func SupportedAlgorithms() []Algorithm {
 	}
 }
 
-// SupportedAlgorithmsStr returns the same content of SupportedAlgorithms but as a slice of string
+// SupportedAlgorithmsStr returns the same content of SupportedAlgorithms but as a slice of string.
 func SupportedAlgorithmsStr() []string {
 	supported := SupportedAlgorithms()
 	supportedStr := make([]string, len(supported))
@@ -28,7 +28,7 @@ func SupportedAlgorithmsStr() []string {
 	return supportedStr
 }
 
-// ECDSACurve represents a type of ECDSA elliptic curve
+// ECDSACurve represents a type of ECDSA elliptic curve.
 type ECDSACurve string
 
 const (
@@ -38,7 +38,7 @@ const (
 	P521 ECDSACurve = "P521"
 )
 
-// SupportedECDSACurves returns an array of ECDSACurve currently supported by this provider
+// SupportedECDSACurves returns an array of ECDSACurve currently supported by this provider.
 func SupportedECDSACurves() []ECDSACurve {
 	return []ECDSACurve{
 		P224,
@@ -48,7 +48,7 @@ func SupportedECDSACurves() []ECDSACurve {
 	}
 }
 
-// SupportedECDSACurvesStr returns the same content of SupportedECDSACurves but as a slice of string
+// SupportedECDSACurvesStr returns the same content of SupportedECDSACurves but as a slice of string.
 func SupportedECDSACurvesStr() []string {
 	supported := SupportedECDSACurves()
 	supportedStr := make([]string, len(supported))


### PR DESCRIPTION
Context: https://github.com/hashicorp/terraform-providers-devex-internal/issues/94

## Description

I'm setting up golangci-lint with the all the defaults enabled, plus some extras. Follows a list of errors that were fixed, separated by "what caught them".

### Default linters (defined [here](https://golangci-lint.run/usage/linters/#enabled-by-default-linters))

```
internal/provider/data_source_public_key.go:82:7: Error return value of `d.Set` is not checked (errcheck)
	d.Set("algorithm", keyAlgo)
	     ^
internal/provider/resource_cert_request.go:137:7: Error return value of `d.Set` is not checked (errcheck)
	d.Set("cert_request_pem", certReqPem)
	     ^
internal/provider/resource_certificate.go:199:7: Error return value of `d.Set` is not checked (errcheck)
	d.Set("cert_pem", certPem)
	     ^
internal/openssh/lib_test.go:29:17: ineffectual assignment to err (ineffassign)
	rawPrivateKey, err := ssh.ParseRawPrivateKey(pemOpenSSHPrvKeyBytes)
	               ^
internal/openssh/lib_test.go:61:17: ineffectual assignment to err (ineffassign)
	rawPrivateKey, err := ssh.ParseRawPrivateKey(pemOpenSSHPrvKeyBytes)
	               ^
internal/openssh/lib_test.go:88:17: ineffectual assignment to err (ineffassign)
	rawPrivateKey, err := ssh.ParseRawPrivateKey(pemOpenSSHPrvKeyBytes)
	               ^
internal/provider/data_source_public_key.go:56:2: SA4006: this value of `bytes` is never used (staticcheck)
	bytes := []byte("")
...
```

### `deadcode, exportloopref, godot, gofmt, gosimple, govet, ineffassign, makezero, misspell, nilerr, staticcheck, structcheck, unconvert, unparam, unused, varcheck`

```
internal/provider/resource_private_key.go:21:22: Comment should end in a period (godot)
// selected algorithm
                     ^
internal/provider/resource_private_key.go:25:39: Comment should end in a period (godot)
// according to the selected algorithm
                                      ^
internal/provider/types.go:3:56: Comment should end in a period (godot)
// Algorithm represents a type of private key algorithm
                                                       ^
internal/provider/resource_certificate.go:135: File is not `gofmt`-ed with `-s` (gofmt)
		"set_subject_key_id": &schema.Schema{
internal/provider/provider.go:35:72: nameFromResourceData - result 1 (error) is always nil (unparam)
func nameFromResourceData(nameMap map[string]interface{}) (*pkix.Name, error) {
                                                                       ^
```

### `predeclared, durationcheck, errcheck`

```
internal/provider/resource_certificate.go:148:45: Multiplication of durations: `time.Duration(d.Get("validity_period_hours").(int)) * time.Hour` (durationcheck)
	template.NotAfter = template.NotBefore.Add(time.Duration(d.Get("validity_period_hours").(int)) * time.Hour)
	                                           ^
internal/provider/resource_certificate.go:234:25: Multiplication of durations: `time.Duration(-d.Get("early_renewal_hours").(int)) * time.Hour` (durationcheck)
		earlyRenewalPeriod := time.Duration(-d.Get("early_renewal_hours").(int)) * time.Hour
```

## Links

* https://golangci-lint.run/usage/linters/
* https://github.com/hashicorp/terraform-plugin-sdk/blob/main/.golangci.yml