### PR TITLE
Adding support for ED25519 to all the `*_cert` resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ NEW FEATURES:
 
 * data-source/tls_public_key: Added support for [ED25519](https://ed25519.cr.yp.to/) key algorithm ([#160](https://github.com/hashicorp/terraform-provider-tls/pull/160)).
 
+* resource/tls_cert_request: Added support for [ED25519](https://ed25519.cr.yp.to/) key algorithm ([#173](https://github.com/hashicorp/terraform-provider-tls/pull/173)).
+
+* resource/tls_self_signed_cert: Added support for [ED25519](https://ed25519.cr.yp.to/) key algorithm ([#173](https://github.com/hashicorp/terraform-provider-tls/pull/173)).
+
+* resource/tls_locally_signed_cert: Added support for [ED25519](https://ed25519.cr.yp.to/) key algorithm ([#173](https://github.com/hashicorp/terraform-provider-tls/pull/173)).
+
 ENHANCEMENTS:
 
 * resource/tls_private_key: New attributes `private_key_openssh` (OpenSSH PEM format) and `public_key_fingerprint_sha256` ([#151](https://github.com/hashicorp/terraform-provider-tls/pull/151)).
@@ -17,12 +23,25 @@ ENHANCEMENTS:
 * resource/tls_locally_signed_cert: Resource will validate that `allowed_uses` list contains values that are part
   of the documented set, throwing an error if they are invalid, instead of silently ignoring it 
   ([#169](https://github.com/hashicorp/terraform-provider-tls/pull/169)).
+* resource/tls_locally_signed_cert: The argument `ca_key_algorithm` is now optional and deprecated, as the resource infers the
+  algorithm from the given key `ca_private_key_pem`. It will be replaced by a read-only attribute, 
+  exposing the inferred algorithm, in the next major release
+  ([#173](https://github.com/hashicorp/terraform-provider-tls/pull/173)).
 
 * resource/tls_self_signed_cert: Resource will validate that `validity_period_hours` and `early_renewal_hours`
   are set to a value greater or equal then zero ([#169](https://github.com/hashicorp/terraform-provider-tls/pull/169)).
 * resource/tls_self_signed_cert: Resource will validate that `allowed_uses` list contains values that are part
   of the documented set, throwing an error if they are invalid, instead of silently ignoring it
   ([#169](https://github.com/hashicorp/terraform-provider-tls/pull/169)).
+* resource/tls_self_signed_cert: The argument `key_algorithm` is now optional and deprecated, as the resource infers the
+  algorithm from the given key `private_key_pem`. It will be replaced by a read-only attribute,
+  exposing the inferred algorithm, in the next major release
+  ([#173](https://github.com/hashicorp/terraform-provider-tls/pull/173)).
+
+* resource/tls_cert_request: The argument `key_algorithm` is now optional and deprecated, as the resource infers the
+  algorithm from the given key `private_key_pem`. It will be replaced by a read-only attribute,
+  exposing the inferred algorithm, in the next major release
+  ([#173](https://github.com/hashicorp/terraform-provider-tls/pull/173)).
 
 NOTES:
 

--- a/docs/resources/cert_request.md
+++ b/docs/resources/cert_request.md
@@ -44,7 +44,7 @@ resource "tls_cert_request" "example" {
 
 - `dns_names` (List of String) List of DNS names for which a certificate is being requested (i.e. certificate subjects).
 - `ip_addresses` (List of String) List of IP addresses for which a certificate is being requested (i.e. certificate subjects).
-- `key_algorithm` (String, Deprecated) Name of the algorithm used when generating the private key provided in `private_key_pem`. **NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key. It it will be made read-only in the next major release.
+- `key_algorithm` (String, Deprecated) Name of the algorithm used when generating the private key provided in `private_key_pem`. **NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key.
 - `uris` (List of String) List of URIs for which a certificate is being requested (i.e. certificate subjects).
 
 ### Read-Only

--- a/docs/resources/cert_request.md
+++ b/docs/resources/cert_request.md
@@ -23,7 +23,6 @@ state and does not create any external managed resources.
 
 ```terraform
 resource "tls_cert_request" "example" {
-  key_algorithm   = "ECDSA"
   private_key_pem = file("private_key.pem")
 
   subject {
@@ -38,7 +37,6 @@ resource "tls_cert_request" "example" {
 
 ### Required
 
-- `key_algorithm` (String) Name of the algorithm used when generating the private key provided in `private_key_pem`.
 - `private_key_pem` (String, Sensitive) Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, that the certificate will belong to. This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file) interpolation function. Only an irreversible secure hash of the private key will be stored in the Terraform state.
 - `subject` (Block List, Min: 1) The subject for which a certificate is being requested. The acceptable arguments are all optional and their naming is based upon [Issuer Distinguished Names (RFC5280)](https://tools.ietf.org/html/rfc5280#section-4.1.2.4) section. (see [below for nested schema](#nestedblock--subject))
 
@@ -46,6 +44,7 @@ resource "tls_cert_request" "example" {
 
 - `dns_names` (List of String) List of DNS names for which a certificate is being requested (i.e. certificate subjects).
 - `ip_addresses` (List of String) List of IP addresses for which a certificate is being requested (i.e. certificate subjects).
+- `key_algorithm` (String, Deprecated) Name of the algorithm used when generating the private key provided in `private_key_pem`. **NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key. It it will be made read-only in the next major release.
 - `uris` (List of String) List of URIs for which a certificate is being requested (i.e. certificate subjects).
 
 ### Read-Only

--- a/docs/resources/locally_signed_cert.md
+++ b/docs/resources/locally_signed_cert.md
@@ -44,7 +44,7 @@ resource "tls_locally_signed_cert" "example" {
 
 ### Optional
 
-- `ca_key_algorithm` (String, Deprecated) Name of the algorithm used when generating the private key provided in `ca_private_key_pem`. **NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key. It it will be made read-only in the next major release.
+- `ca_key_algorithm` (String, Deprecated) Name of the algorithm used when generating the private key provided in `ca_private_key_pem`. **NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key.
 - `early_renewal_hours` (Number) The resource will consider the certificate to have expired the given number of hours before its actual expiry time. This can be useful to deploy an updated certificate in advance of the expiration of the current certificate. However, the old certificate remains valid until its true expiration time, since this resource does not (and cannot) support certificate revocation. Also, this advance update can only be performed should the Terraform configuration be applied during the early renewal period. (default: `0`)
 - `is_ca_certificate` (Boolean) Is the generated certificate representing a Certificate Authority (CA) (default: `false`).
 - `set_subject_key_id` (Boolean) Should the generated certificate include a subject key identifier (default: `false`).

--- a/docs/resources/locally_signed_cert.md
+++ b/docs/resources/locally_signed_cert.md
@@ -18,7 +18,6 @@ or when deployed internally to an organization.
 ```terraform
 resource "tls_locally_signed_cert" "example" {
   cert_request_pem   = file("cert_request.pem")
-  ca_key_algorithm   = "ECDSA"
   ca_private_key_pem = file("ca_private_key.pem")
   ca_cert_pem        = file("ca_cert.pem")
 
@@ -39,13 +38,13 @@ resource "tls_locally_signed_cert" "example" {
 
 - `allowed_uses` (List of String) List of key usages allowed for the issued certificate. Values are defined in [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280) and combine flags defined by both [Key Usages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3) and [Extended Key Usages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12). Accepted values: `any_extended`, `cert_signing`, `client_auth`, `code_signing`, `content_commitment`, `crl_signing`, `data_encipherment`, `decipher_only`, `digital_signature`, `email_protection`, `encipher_only`, `ipsec_end_system`, `ipsec_tunnel`, `ipsec_user`, `key_agreement`, `key_encipherment`, `microsoft_commercial_code_signing`, `microsoft_kernel_code_signing`, `microsoft_server_gated_crypto`, `netscape_server_gated_crypto`, `ocsp_signing`, `server_auth`, `timestamping`.
 - `ca_cert_pem` (String) Certificate data of the Certificate Authority (CA) in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format.
-- `ca_key_algorithm` (String) Name of the algorithm used when generating the private key provided in `ca_private_key_pem`.
 - `ca_private_key_pem` (String, Sensitive) Private key of the Certificate Authority (CA) used to sign the certificate, in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format.
 - `cert_request_pem` (String) Certificate request data in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format.
 - `validity_period_hours` (Number) Number of hours, after initial issuing, that the certificate will remain valid for.
 
 ### Optional
 
+- `ca_key_algorithm` (String, Deprecated) Name of the algorithm used when generating the private key provided in `ca_private_key_pem`. **NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key. It it will be made read-only in the next major release.
 - `early_renewal_hours` (Number) The resource will consider the certificate to have expired the given number of hours before its actual expiry time. This can be useful to deploy an updated certificate in advance of the expiration of the current certificate. However, the old certificate remains valid until its true expiration time, since this resource does not (and cannot) support certificate revocation. Also, this advance update can only be performed should the Terraform configuration be applied during the early renewal period. (default: `0`)
 - `is_ca_certificate` (Boolean) Is the generated certificate representing a Certificate Authority (CA) (default: `false`).
 - `set_subject_key_id` (Boolean) Should the generated certificate include a subject key identifier (default: `false`).

--- a/docs/resources/self_signed_cert.md
+++ b/docs/resources/self_signed_cert.md
@@ -19,7 +19,6 @@ connecting to a server that has a self-signed certificate.
 
 ```terraform
 resource "tls_self_signed_cert" "example" {
-  key_algorithm   = "ECDSA"
   private_key_pem = file("private_key.pem")
 
   subject {
@@ -43,7 +42,6 @@ resource "tls_self_signed_cert" "example" {
 ### Required
 
 - `allowed_uses` (List of String) List of key usages allowed for the issued certificate. Values are defined in [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280) and combine flags defined by both [Key Usages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3) and [Extended Key Usages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12). Accepted values: `any_extended`, `cert_signing`, `client_auth`, `code_signing`, `content_commitment`, `crl_signing`, `data_encipherment`, `decipher_only`, `digital_signature`, `email_protection`, `encipher_only`, `ipsec_end_system`, `ipsec_tunnel`, `ipsec_user`, `key_agreement`, `key_encipherment`, `microsoft_commercial_code_signing`, `microsoft_kernel_code_signing`, `microsoft_server_gated_crypto`, `netscape_server_gated_crypto`, `ocsp_signing`, `server_auth`, `timestamping`.
-- `key_algorithm` (String) Name of the algorithm used when generating the private key provided in `private_key_pem`.
 - `private_key_pem` (String, Sensitive) Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, that the certificate will belong to. This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file) interpolation function. Only an irreversible secure hash of the private key will be stored in the Terraform state.
 - `subject` (Block List, Min: 1) The subject for which a certificate is being requested. The acceptable arguments are all optional and their naming is based upon [Issuer Distinguished Names (RFC5280)](https://tools.ietf.org/html/rfc5280#section-4.1.2.4) section. (see [below for nested schema](#nestedblock--subject))
 - `validity_period_hours` (Number) Number of hours, after initial issuing, that the certificate will remain valid for.
@@ -54,6 +52,7 @@ resource "tls_self_signed_cert" "example" {
 - `early_renewal_hours` (Number) The resource will consider the certificate to have expired the given number of hours before its actual expiry time. This can be useful to deploy an updated certificate in advance of the expiration of the current certificate. However, the old certificate remains valid until its true expiration time, since this resource does not (and cannot) support certificate revocation. Also, this advance update can only be performed should the Terraform configuration be applied during the early renewal period. (default: `0`)
 - `ip_addresses` (List of String) List of IP addresses for which a certificate is being requested (i.e. certificate subjects).
 - `is_ca_certificate` (Boolean) Is the generated certificate representing a Certificate Authority (CA) (default: `false`).
+- `key_algorithm` (String, Deprecated) Name of the algorithm used when generating the private key provided in `private_key_pem`. **NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key. It it will be made read-only in the next major release.
 - `set_subject_key_id` (Boolean) Should the generated certificate include a subject key identifier (default: `false`).
 - `uris` (List of String) List of URIs for which a certificate is being requested (i.e. certificate subjects).
 

--- a/docs/resources/self_signed_cert.md
+++ b/docs/resources/self_signed_cert.md
@@ -52,7 +52,7 @@ resource "tls_self_signed_cert" "example" {
 - `early_renewal_hours` (Number) The resource will consider the certificate to have expired the given number of hours before its actual expiry time. This can be useful to deploy an updated certificate in advance of the expiration of the current certificate. However, the old certificate remains valid until its true expiration time, since this resource does not (and cannot) support certificate revocation. Also, this advance update can only be performed should the Terraform configuration be applied during the early renewal period. (default: `0`)
 - `ip_addresses` (List of String) List of IP addresses for which a certificate is being requested (i.e. certificate subjects).
 - `is_ca_certificate` (Boolean) Is the generated certificate representing a Certificate Authority (CA) (default: `false`).
-- `key_algorithm` (String, Deprecated) Name of the algorithm used when generating the private key provided in `private_key_pem`. **NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key. It it will be made read-only in the next major release.
+- `key_algorithm` (String, Deprecated) Name of the algorithm used when generating the private key provided in `private_key_pem`. **NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key.
 - `set_subject_key_id` (Boolean) Should the generated certificate include a subject key identifier (default: `false`).
 - `uris` (List of String) List of URIs for which a certificate is being requested (i.e. certificate subjects).
 

--- a/examples/resources/tls_cert_request/resource.tf
+++ b/examples/resources/tls_cert_request/resource.tf
@@ -1,5 +1,4 @@
 resource "tls_cert_request" "example" {
-  key_algorithm   = "ECDSA"
   private_key_pem = file("private_key.pem")
 
   subject {

--- a/examples/resources/tls_locally_signed_cert/resource.tf
+++ b/examples/resources/tls_locally_signed_cert/resource.tf
@@ -1,6 +1,5 @@
 resource "tls_locally_signed_cert" "example" {
   cert_request_pem   = file("cert_request.pem")
-  ca_key_algorithm   = "ECDSA"
   ca_private_key_pem = file("ca_private_key.pem")
   ca_cert_pem        = file("ca_cert.pem")
 

--- a/examples/resources/tls_self_signed_cert/resource.tf
+++ b/examples/resources/tls_self_signed_cert/resource.tf
@@ -1,5 +1,4 @@
 resource "tls_self_signed_cert" "example" {
-  key_algorithm   = "ECDSA"
   private_key_pem = file("private_key.pem")
 
   subject {

--- a/internal/provider/common_cert.go
+++ b/internal/provider/common_cert.go
@@ -349,7 +349,7 @@ func createCertificate(d *schema.ResourceData, template, parent *x509.Certificat
 	if err != nil {
 		return fmt.Errorf("error creating certificate: %s", err)
 	}
-	certPem := string(pem.EncodeToMemory(&pem.Block{Type: Certificate.String(), Bytes: certBytes}))
+	certPem := string(pem.EncodeToMemory(&pem.Block{Type: PreambleCertificate.String(), Bytes: certBytes}))
 
 	validFromBytes, err := template.NotBefore.MarshalText()
 	if err != nil {
@@ -485,7 +485,7 @@ func parseCertificate(d *schema.ResourceData, pemKey string) (*x509.Certificate,
 }
 
 func parseCertificateRequest(d *schema.ResourceData, pemKey string) (*x509.CertificateRequest, error) {
-	block, err := decodePEM(d, pemKey, CertificateRequest.String())
+	block, err := decodePEM(d, pemKey, PreambleCertificateRequest.String())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/common_cert.go
+++ b/internal/provider/common_cert.go
@@ -122,10 +122,14 @@ func setCertificateSubjectSchema(s map[string]*schema.Schema) {
 	}
 
 	s["key_algorithm"] = &schema.Schema{
-		Type:        schema.TypeString,
-		Required:    true,
-		ForceNew:    true,
-		Description: "Name of the algorithm used when generating the private key provided in `private_key_pem`.",
+		Type:     schema.TypeString,
+		Optional: true,
+		ForceNew: true,
+		Deprecated: "This is now ignored, as the key algorithm is inferred from the `private_key_pem`. " +
+			"It it will be made read-only in the next major release.",
+		Description: "Name of the algorithm used when generating the private key provided in `private_key_pem`. " +
+			"**NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key. " +
+			"It it will be made read-only in the next major release.",
 	}
 
 	s["private_key_pem"] = &schema.Schema{

--- a/internal/provider/common_cert.go
+++ b/internal/provider/common_cert.go
@@ -124,6 +124,7 @@ func setCertificateSubjectSchema(s map[string]*schema.Schema) {
 	s["key_algorithm"] = &schema.Schema{
 		Type:       schema.TypeString,
 		Optional:   true,
+		Computed:   true,
 		ForceNew:   true,
 		Deprecated: "This is now ignored, as the key algorithm is inferred from the `private_key_pem`.",
 		Description: "Name of the algorithm used when generating the private key provided in `private_key_pem`. " +

--- a/internal/provider/common_cert.go
+++ b/internal/provider/common_cert.go
@@ -122,14 +122,12 @@ func setCertificateSubjectSchema(s map[string]*schema.Schema) {
 	}
 
 	s["key_algorithm"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Optional: true,
-		ForceNew: true,
-		Deprecated: "This is now ignored, as the key algorithm is inferred from the `private_key_pem`. " +
-			"It it will be made read-only in the next major release.",
+		Type:       schema.TypeString,
+		Optional:   true,
+		ForceNew:   true,
+		Deprecated: "This is now ignored, as the key algorithm is inferred from the `private_key_pem`.",
 		Description: "Name of the algorithm used when generating the private key provided in `private_key_pem`. " +
-			"**NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key. " +
-			"It it will be made read-only in the next major release.",
+			"**NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key. ",
 	}
 
 	s["private_key_pem"] = &schema.Schema{

--- a/internal/provider/common_key.go
+++ b/internal/provider/common_key.go
@@ -1,0 +1,136 @@
+package provider
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"golang.org/x/crypto/ssh"
+)
+
+// parsePrivateKeyPEM takes a slide of bytes containing a private key
+// encoded in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format,
+// and returns a crypto.PrivateKey implementation, together with the Algorithm used by the key.
+func parsePrivateKeyPEM(keyPEMBytes []byte) (crypto.PrivateKey, Algorithm, error) {
+	pemBlock, rest := pem.Decode(keyPEMBytes)
+	if pemBlock == nil {
+		return nil, "", fmt.Errorf("failed to decode PEM block: decoded bytes %d, undecoded %d", len(keyPEMBytes)-len(rest), len(rest))
+	}
+
+	// Map PEM Preamble of the Private Key to the corresponding Algorithm
+	algorithm, err := PEMPreamblePrivateKey(pemBlock.Type).Algorithm()
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Identify parser for the given key, using the Algorithm
+	parser, ok := keyParsers[algorithm]
+	if !ok {
+		return nil, "", fmt.Errorf("unsupported key algorithm: %s", algorithm)
+	}
+
+	// Parse the specific crypto.PrivateKey from the PEM Block bytes
+	prvKey, err := parser(pemBlock.Bytes)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to parse private key of algorithm %s: %w", algorithm, err)
+	}
+
+	return prvKey, algorithm, nil
+}
+
+// parsePrivateKeyOpenSSHPEM takes a slide of bytes containing a private key
+// encoded in [OpenSSH PEM (RFC 4716)](https://datatracker.ietf.org/doc/html/rfc4716) format,
+// and returns a crypto.PrivateKey implementation, together with the Algorithm used by the key.
+func parsePrivateKeyOpenSSHPEM(keyOpenSSHPEMBytes []byte) (crypto.PrivateKey, Algorithm, error) {
+	prvKey, err := ssh.ParseRawPrivateKey(keyOpenSSHPEMBytes)
+	if err != nil {
+		return nil, "", err
+	}
+
+	algorithm, err := privateKeyToAlgorithm(prvKey)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return prvKey, algorithm, nil
+}
+
+// privateKeyToPublicKey takes a crypto.PrivateKey and extracts the corresponding crypto.PublicKey,
+// after having figured out its type.
+func privateKeyToPublicKey(prvKey crypto.PrivateKey) crypto.PublicKey {
+	switch k := prvKey.(type) {
+	case *rsa.PrivateKey:
+		return &k.PublicKey
+	case *ecdsa.PrivateKey:
+		return &k.PublicKey
+	case *ed25519.PrivateKey:
+		return k.Public()
+	default:
+		return nil
+	}
+}
+
+// privateKeyToAlgorithm identifies the Algorithm used by a given crypto.PrivateKey.
+func privateKeyToAlgorithm(prvKey crypto.PrivateKey) (Algorithm, error) {
+	switch k := prvKey.(type) {
+	case *rsa.PrivateKey:
+		return RSA, nil
+	case *ecdsa.PrivateKey:
+		return ECDSA, nil
+	case *ed25519.PrivateKey:
+		return ED25519, nil
+	default:
+		return "", fmt.Errorf("failed to identify key algorithm for unsupported private key: %#v", k)
+	}
+}
+
+// setPublicKeyAttributes takes a crypto.PrivateKey, extracts the corresponding crypto.PublicKey and then
+// encodes related attributes on the given schema.ResourceData.
+func setPublicKeyAttributes(d *schema.ResourceData, prvKey crypto.PrivateKey) error {
+	pubKey := privateKeyToPublicKey(prvKey)
+	pubKeyBytes, err := x509.MarshalPKIXPublicKey(pubKey)
+	if err != nil {
+		return fmt.Errorf("failed to marshal public key error: %s", err)
+	}
+	pubKeyPemBlock := &pem.Block{
+		Type:  PublicKey.String(),
+		Bytes: pubKeyBytes,
+	}
+
+	d.SetId(hashForState(string(pubKeyBytes)))
+
+	if err := d.Set("public_key_pem", string(pem.EncodeToMemory(pubKeyPemBlock))); err != nil {
+		return fmt.Errorf("error setting value on key 'public_key_pem': %s", err)
+	}
+
+	// NOTE: ECDSA keys with elliptic curve P-224 are not supported by `x/crypto/ssh`,
+	// so this will return an error: in that case, we set the below fields to emptry strings
+	sshPubKey, err := ssh.NewPublicKey(privateKeyToPublicKey(prvKey))
+	var pubKeySSH, pubKeySSHFingerprintMD5, pubKeySSHFingerprintSHA256 string
+	if err == nil {
+		sshPubKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
+
+		pubKeySSH = string(sshPubKeyBytes)
+		pubKeySSHFingerprintMD5 = ssh.FingerprintLegacyMD5(sshPubKey)
+		pubKeySSHFingerprintSHA256 = ssh.FingerprintSHA256(sshPubKey)
+	}
+
+	if err := d.Set("public_key_openssh", pubKeySSH); err != nil {
+		return fmt.Errorf("error setting value on key 'public_key_openssh': %s", err)
+	}
+
+	if err := d.Set("public_key_fingerprint_md5", pubKeySSHFingerprintMD5); err != nil {
+		return fmt.Errorf("error setting value on key 'public_key_fingerprint_md5': %s", err)
+	}
+
+	if err := d.Set("public_key_fingerprint_sha256", pubKeySSHFingerprintSHA256); err != nil {
+		return fmt.Errorf("error setting value on key 'public_key_fingerprint_sha256': %s", err)
+	}
+
+	return nil
+}

--- a/internal/provider/data_source_public_key_test.go
+++ b/internal/provider/data_source_public_key_test.go
@@ -73,7 +73,7 @@ func TestAccPublicKey_dataSource_PEM(t *testing.T) {
 			},
 			{
 				Config:      fmt.Sprintf(configDataSourcePublicKeyViaPEM, "corrupt"),
-				ExpectError: regexp.MustCompile(`failed to decode raw PEM block: decoded bytes \d, undecoded \d`),
+				ExpectError: regexp.MustCompile(`failed to decode PEM block: decoded bytes \d, undecoded \d`),
 			},
 		},
 	})

--- a/internal/provider/resource_cert_request.go
+++ b/internal/provider/resource_cert_request.go
@@ -89,7 +89,7 @@ func CreateCertRequest(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error creating certificate request: %s", err)
 	}
-	certReqPem := string(pem.EncodeToMemory(&pem.Block{Type: CertificateRequest.String(), Bytes: certReqBytes}))
+	certReqPem := string(pem.EncodeToMemory(&pem.Block{Type: PreambleCertificateRequest.String(), Bytes: certReqBytes}))
 
 	d.SetId(hashForState(string(certReqBytes)))
 

--- a/internal/provider/resource_cert_request.go
+++ b/internal/provider/resource_cert_request.go
@@ -30,9 +30,9 @@ func resourceCertRequest() *schema.Resource {
 	setCertificateSubjectSchema(s)
 
 	return &schema.Resource{
-		Create: CreateCertRequest,
-		Delete: DeleteCertRequest,
-		Read:   ReadCertRequest,
+		Create: createCertRequest,
+		Delete: deleteCertRequest,
+		Read:   readCertRequest,
 
 		Description: "Creates a Certificate Signing Request (CSR) in " +
 			"[PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format.\n\n" +
@@ -44,10 +44,14 @@ func resourceCertRequest() *schema.Resource {
 	}
 }
 
-func CreateCertRequest(d *schema.ResourceData, meta interface{}) error {
-	key, _, err := parsePrivateKeyPEM([]byte(d.Get("private_key_pem").(string)))
+func createCertRequest(d *schema.ResourceData, meta interface{}) error {
+	key, algorithm, err := parsePrivateKeyPEM([]byte(d.Get("private_key_pem").(string)))
 	if err != nil {
 		return err
+	}
+
+	if err := d.Set("key_algorithm", algorithm); err != nil {
+		return fmt.Errorf("error setting value on key 'key_algorithm': %s", err)
 	}
 
 	subjectConfs := d.Get("subject").([]interface{})
@@ -100,11 +104,11 @@ func CreateCertRequest(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func DeleteCertRequest(d *schema.ResourceData, meta interface{}) error {
+func deleteCertRequest(d *schema.ResourceData, meta interface{}) error {
 	d.SetId("")
 	return nil
 }
 
-func ReadCertRequest(d *schema.ResourceData, meta interface{}) error {
+func readCertRequest(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }

--- a/internal/provider/resource_cert_request.go
+++ b/internal/provider/resource_cert_request.go
@@ -45,7 +45,7 @@ func resourceCertRequest() *schema.Resource {
 }
 
 func CreateCertRequest(d *schema.ResourceData, meta interface{}) error {
-	key, err := parsePrivateKey(d, "private_key_pem", "key_algorithm")
+	key, _, err := parsePrivateKeyPEM([]byte(d.Get("private_key_pem").(string)))
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_cert_request_test.go
+++ b/internal/provider/resource_cert_request_test.go
@@ -220,9 +220,7 @@ func TestCertRequest_HandleKeyAlgorithmDeprecation(t *testing.T) {
 						private_key_pem = tls_private_key.test.private_key_pem
 					}
 				`,
-				Check: r.ComposeAggregateTestCheckFunc(
-					r.TestCheckResourceAttr("tls_cert_request.test", "key_algorithm", "RSA"),
-				),
+				Check: r.TestCheckResourceAttr("tls_cert_request.test", "key_algorithm", "RSA"),
 			},
 			{
 				Config: `
@@ -236,9 +234,7 @@ func TestCertRequest_HandleKeyAlgorithmDeprecation(t *testing.T) {
 						private_key_pem = tls_private_key.test.private_key_pem
 					}
 				`,
-				Check: r.ComposeAggregateTestCheckFunc(
-					r.TestCheckNoResourceAttr("tls_cert_request.test", "key_algorithm"),
-				),
+				Check: r.TestCheckResourceAttr("tls_cert_request.test", "key_algorithm", "RSA"),
 			},
 		},
 	},

--- a/internal/provider/resource_cert_request_test.go
+++ b/internal/provider/resource_cert_request_test.go
@@ -201,3 +201,45 @@ EOT
 		},
 	})
 }
+
+func TestCertRequest_HandleKeyAlgorithmDeprecation(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		Providers: testProviders,
+		Steps: []r.TestStep{
+			{
+				Config: `
+					resource "tls_private_key" "test" {
+						algorithm = "RSA"
+					}
+					resource "tls_cert_request" "test" {
+						subject {
+							serial_number = "42"
+						}
+						key_algorithm = "RSA"
+						private_key_pem = tls_private_key.test.private_key_pem
+					}
+				`,
+				Check: r.ComposeAggregateTestCheckFunc(
+					r.TestCheckResourceAttr("tls_cert_request.test", "key_algorithm", "RSA"),
+				),
+			},
+			{
+				Config: `
+					resource "tls_private_key" "test" {
+						algorithm = "RSA"
+					}
+					resource "tls_cert_request" "test" {
+						subject {
+							serial_number = "42"
+						}
+						private_key_pem = tls_private_key.test.private_key_pem
+					}
+				`,
+				Check: r.ComposeAggregateTestCheckFunc(
+					r.TestCheckNoResourceAttr("tls_cert_request.test", "key_algorithm"),
+				),
+			},
+		},
+	},
+	)
+}

--- a/internal/provider/resource_cert_request_test.go
+++ b/internal/provider/resource_cert_request_test.go
@@ -202,6 +202,7 @@ EOT
 	})
 }
 
+// TODO Remove this as part of https://github.com/hashicorp/terraform-provider-tls/issues/174
 func TestCertRequest_HandleKeyAlgorithmDeprecation(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,

--- a/internal/provider/resource_cert_request_test.go
+++ b/internal/provider/resource_cert_request_test.go
@@ -45,7 +45,6 @@ func TestCertRequest(t *testing.T) {
                             "spiffe://example-trust-domain/workload2",
                         ]
 
-                        key_algorithm = "RSA"
                         private_key_pem = <<EOT
 %s
 EOT
@@ -138,7 +137,6 @@ EOT
 						serial_number = "42"
 						}
 
-                        key_algorithm = "RSA"
                         private_key_pem = <<EOT
 %s
 EOT

--- a/internal/provider/resource_locally_signed_cert.go
+++ b/internal/provider/resource_locally_signed_cert.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"crypto/x509"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -25,6 +26,7 @@ func resourceLocallySignedCert() *schema.Resource {
 	s["ca_key_algorithm"] = &schema.Schema{
 		Type:       schema.TypeString,
 		Optional:   true,
+		Computed:   true,
 		ForceNew:   true,
 		Deprecated: "This is now ignored, as the key algorithm is inferred from the `ca_private_key_pem`.",
 		Description: "Name of the algorithm used when generating the private key provided in `ca_private_key_pem`. " +
@@ -72,10 +74,16 @@ func createLocallySignedCert(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	caKey, _, err := parsePrivateKeyPEM([]byte(d.Get("ca_private_key_pem").(string)))
+
+	caKey, algorithm, err := parsePrivateKeyPEM([]byte(d.Get("ca_private_key_pem").(string)))
 	if err != nil {
 		return err
 	}
+
+	if err := d.Set("ca_key_algorithm", algorithm); err != nil {
+		return fmt.Errorf("error setting value on key 'ca_key_algorithm': %s", err)
+	}
+
 	caCert, err := parseCertificate(d, "ca_cert_pem")
 	if err != nil {
 		return err

--- a/internal/provider/resource_locally_signed_cert.go
+++ b/internal/provider/resource_locally_signed_cert.go
@@ -23,10 +23,14 @@ func resourceLocallySignedCert() *schema.Resource {
 	}
 
 	s["ca_key_algorithm"] = &schema.Schema{
-		Type:        schema.TypeString,
-		Required:    true,
-		ForceNew:    true,
-		Description: "Name of the algorithm used when generating the private key provided in `ca_private_key_pem`.",
+		Type:     schema.TypeString,
+		Optional: true,
+		ForceNew: true,
+		Deprecated: "This is now ignored, as the key algorithm is inferred from the `private_key_pem`. " +
+			"It it will be made read-only in the next major release.",
+		Description: "Name of the algorithm used when generating the private key provided in `ca_private_key_pem`. " +
+			"**NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key. " +
+			"It it will be made read-only in the next major release.",
 	}
 
 	s["ca_private_key_pem"] = &schema.Schema{

--- a/internal/provider/resource_locally_signed_cert.go
+++ b/internal/provider/resource_locally_signed_cert.go
@@ -23,14 +23,12 @@ func resourceLocallySignedCert() *schema.Resource {
 	}
 
 	s["ca_key_algorithm"] = &schema.Schema{
-		Type:     schema.TypeString,
-		Optional: true,
-		ForceNew: true,
-		Deprecated: "This is now ignored, as the key algorithm is inferred from the `private_key_pem`. " +
-			"It it will be made read-only in the next major release.",
+		Type:       schema.TypeString,
+		Optional:   true,
+		ForceNew:   true,
+		Deprecated: "This is now ignored, as the key algorithm is inferred from the `ca_private_key_pem`.",
 		Description: "Name of the algorithm used when generating the private key provided in `ca_private_key_pem`. " +
-			"**NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key. " +
-			"It it will be made read-only in the next major release.",
+			"**NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key. ",
 	}
 
 	s["ca_private_key_pem"] = &schema.Schema{

--- a/internal/provider/resource_locally_signed_cert.go
+++ b/internal/provider/resource_locally_signed_cert.go
@@ -70,7 +70,7 @@ func createLocallySignedCert(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	caKey, err := parsePrivateKey(d, "ca_private_key_pem", "ca_key_algorithm")
+	caKey, _, err := parsePrivateKeyPEM([]byte(d.Get("ca_private_key_pem").(string)))
 	if err != nil {
 		return err
 	}

--- a/internal/provider/resource_locally_signed_cert_test.go
+++ b/internal/provider/resource_locally_signed_cert_test.go
@@ -18,7 +18,7 @@ func TestLocallySignedCert(t *testing.T) {
 		Providers: testProviders,
 		Steps: []r.TestStep{
 			{
-				Config: locallySignedCertConfig(1, 0),
+				Config: locallySignedCertConfig(1, 0, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["cert_pem"].Value
 					got, ok := gotUntyped.(string)
@@ -151,7 +151,7 @@ func TestAccLocallySignedCertRecreatesAfterExpired(t *testing.T) {
 		PreCheck:  setTimeForTest("2019-06-14T12:00:00Z"),
 		Steps: []r.TestStep{
 			{
-				Config: locallySignedCertConfig(10, 2),
+				Config: locallySignedCertConfig(10, 2, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["cert_pem"].Value
 					got, ok := gotUntyped.(string)
@@ -163,7 +163,7 @@ func TestAccLocallySignedCertRecreatesAfterExpired(t *testing.T) {
 				},
 			},
 			{
-				Config: locallySignedCertConfig(10, 2),
+				Config: locallySignedCertConfig(10, 2, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["cert_pem"].Value
 					got, ok := gotUntyped.(string)
@@ -181,7 +181,7 @@ func TestAccLocallySignedCertRecreatesAfterExpired(t *testing.T) {
 			},
 			{
 				PreConfig: setTimeForTest("2019-06-14T19:00:00Z"),
-				Config:    locallySignedCertConfig(10, 2),
+				Config:    locallySignedCertConfig(10, 2, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["cert_pem"].Value
 					got, ok := gotUntyped.(string)
@@ -199,7 +199,7 @@ func TestAccLocallySignedCertRecreatesAfterExpired(t *testing.T) {
 			},
 			{
 				PreConfig: setTimeForTest("2019-06-14T21:00:00Z"),
-				Config:    locallySignedCertConfig(10, 2),
+				Config:    locallySignedCertConfig(10, 2, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["cert_pem"].Value
 					got, ok := gotUntyped.(string)
@@ -228,7 +228,7 @@ func TestAccLocallySignedCertNotRecreatedForEarlyRenewalUpdateInFuture(t *testin
 		PreCheck:  setTimeForTest("2019-06-14T12:00:00Z"),
 		Steps: []r.TestStep{
 			{
-				Config: locallySignedCertConfig(10, 2),
+				Config: locallySignedCertConfig(10, 2, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["cert_pem"].Value
 					got, ok := gotUntyped.(string)
@@ -240,25 +240,7 @@ func TestAccLocallySignedCertNotRecreatedForEarlyRenewalUpdateInFuture(t *testin
 				},
 			},
 			{
-				Config: locallySignedCertConfig(10, 3),
-				Check: func(s *terraform.State) error {
-					gotUntyped := s.RootModule().Outputs["cert_pem"].Value
-					got, ok := gotUntyped.(string)
-					if !ok {
-						return fmt.Errorf("output for \"cert_pem\" is not a string")
-					}
-
-					if got != previousCert {
-						return fmt.Errorf("certificate updated even though still time until early renewal")
-					}
-
-					previousCert = got
-					return nil
-				},
-			},
-			{
-				PreConfig: setTimeForTest("2019-06-14T16:00:00Z"),
-				Config:    locallySignedCertConfig(10, 3),
+				Config: locallySignedCertConfig(10, 3, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["cert_pem"].Value
 					got, ok := gotUntyped.(string)
@@ -276,7 +258,25 @@ func TestAccLocallySignedCertNotRecreatedForEarlyRenewalUpdateInFuture(t *testin
 			},
 			{
 				PreConfig: setTimeForTest("2019-06-14T16:00:00Z"),
-				Config:    locallySignedCertConfig(10, 9),
+				Config:    locallySignedCertConfig(10, 3, false),
+				Check: func(s *terraform.State) error {
+					gotUntyped := s.RootModule().Outputs["cert_pem"].Value
+					got, ok := gotUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"cert_pem\" is not a string")
+					}
+
+					if got != previousCert {
+						return fmt.Errorf("certificate updated even though still time until early renewal")
+					}
+
+					previousCert = got
+					return nil
+				},
+			},
+			{
+				PreConfig: setTimeForTest("2019-06-14T16:00:00Z"),
+				Config:    locallySignedCertConfig(10, 9, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["cert_pem"].Value
 					got, ok := gotUntyped.(string)
@@ -297,7 +297,143 @@ func TestAccLocallySignedCertNotRecreatedForEarlyRenewalUpdateInFuture(t *testin
 	overridableTimeFunc = oldNow
 }
 
-func locallySignedCertConfig(validity uint32, earlyRenewal uint32) string {
+// TODO Remove this as part of https://github.com/hashicorp/terraform-provider-tls/issues/174
+func TestAccLocallySignedCert_HandleKeyAlgorithmDeprecation(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		Providers: testProviders,
+		Steps: []r.TestStep{
+			{
+				Config: locallySignedCertConfig(1, 0, true),
+				Check: func(s *terraform.State) error {
+					gotUntyped := s.RootModule().Outputs["cert_pem"].Value
+					got, ok := gotUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"cert_pem\" is not a string")
+					}
+					if !strings.HasPrefix(got, "-----BEGIN CERTIFICATE----") {
+						return fmt.Errorf("key is missing cert PEM preamble")
+					}
+					block, _ := pem.Decode([]byte(got))
+					cert, err := x509.ParseCertificate(block.Bytes)
+					if err != nil {
+						return fmt.Errorf("error parsing cert: %s", err)
+					}
+					if expected, got := "2", cert.Subject.SerialNumber; got != expected {
+						return fmt.Errorf("incorrect subject serial number: expected %v, got %v", expected, got)
+					}
+					if expected, got := "example.com", cert.Subject.CommonName; got != expected {
+						return fmt.Errorf("incorrect subject common name: expected %v, got %v", expected, got)
+					}
+					if expected, got := "Example, Inc", cert.Subject.Organization[0]; got != expected {
+						return fmt.Errorf("incorrect subject organization: expected %v, got %v", expected, got)
+					}
+					if expected, got := "Department of Terraform Testing", cert.Subject.OrganizationalUnit[0]; got != expected {
+						return fmt.Errorf("incorrect subject organizational unit: expected %v, got %v", expected, got)
+					}
+					if expected, got := "5879 Cotton Link", cert.Subject.StreetAddress[0]; got != expected {
+						return fmt.Errorf("incorrect subject street address: expected %v, got %v", expected, got)
+					}
+					if expected, got := "Pirate Harbor", cert.Subject.Locality[0]; got != expected {
+						return fmt.Errorf("incorrect subject locality: expected %v, got %v", expected, got)
+					}
+					if expected, got := "CA", cert.Subject.Province[0]; got != expected {
+						return fmt.Errorf("incorrect subject province: expected %v, got %v", expected, got)
+					}
+					if expected, got := "US", cert.Subject.Country[0]; got != expected {
+						return fmt.Errorf("incorrect subject country: expected %v, got %v", expected, got)
+					}
+					if expected, got := "95559-1227", cert.Subject.PostalCode[0]; got != expected {
+						return fmt.Errorf("incorrect subject postal code: expected %v, got %v", expected, got)
+					}
+
+					if expected, got := 2, len(cert.DNSNames); got != expected {
+						return fmt.Errorf("incorrect number of DNS names: expected %v, got %v", expected, got)
+					}
+					if expected, got := "example.com", cert.DNSNames[0]; got != expected {
+						return fmt.Errorf("incorrect DNS name 0: expected %v, got %v", expected, got)
+					}
+					if expected, got := "example.net", cert.DNSNames[1]; got != expected {
+						return fmt.Errorf("incorrect DNS name 0: expected %v, got %v", expected, got)
+					}
+
+					if expected, got := 2, len(cert.IPAddresses); got != expected {
+						return fmt.Errorf("incorrect number of IP addresses: expected %v, got %v", expected, got)
+					}
+					if expected, got := "127.0.0.1", cert.IPAddresses[0].String(); got != expected {
+						return fmt.Errorf("incorrect IP address 0: expected %v, got %v", expected, got)
+					}
+					if expected, got := "127.0.0.2", cert.IPAddresses[1].String(); got != expected {
+						return fmt.Errorf("incorrect IP address 0: expected %v, got %v", expected, got)
+					}
+					if expected, got := 2, len(cert.URIs); got != expected {
+						return fmt.Errorf("incorrect number of URIs: expected %v, got %v", expected, got)
+					}
+					if expected, got := "spiffe://example-trust-domain/workload", cert.URIs[0].String(); got != expected {
+						return fmt.Errorf("incorrect URI 0: expected %v, got %v", expected, got)
+					}
+					if expected, got := "spiffe://example-trust-domain/workload2", cert.URIs[1].String(); got != expected {
+						return fmt.Errorf("incorrect URI 1: expected %v, got %v", expected, got)
+					}
+
+					if expected, got := 2, len(cert.ExtKeyUsage); got != expected {
+						return fmt.Errorf("incorrect number of ExtKeyUsage: expected %v, got %v", expected, got)
+					}
+					if expected, got := x509.ExtKeyUsageServerAuth, cert.ExtKeyUsage[0]; got != expected {
+						return fmt.Errorf("incorrect ExtKeyUsage[0]: expected %v, got %v", expected, got)
+					}
+					if expected, got := x509.ExtKeyUsageClientAuth, cert.ExtKeyUsage[1]; got != expected {
+						return fmt.Errorf("incorrect ExtKeyUsage[1]: expected %v, got %v", expected, got)
+					}
+
+					if expected, got := x509.KeyUsageKeyEncipherment|x509.KeyUsageDigitalSignature, cert.KeyUsage; got != expected {
+						return fmt.Errorf("incorrect KeyUsage: expected %v, got %v", expected, got)
+					}
+
+					// This time checking is a bit sloppy to avoid inconsistent test results
+					// depending on the power of the machine running the tests.
+					now := time.Now()
+					if cert.NotBefore.After(now) {
+						return fmt.Errorf("certificate validity begins in the future")
+					}
+					if now.Sub(cert.NotBefore) > (2 * time.Minute) {
+						return fmt.Errorf("certificate validity begins more than two minutes in the past")
+					}
+					if cert.NotAfter.Sub(cert.NotBefore) != time.Hour {
+						return fmt.Errorf("certificate validity is not one hour")
+					}
+
+					caBlock, _ := pem.Decode([]byte(testCACert))
+					caCert, err := x509.ParseCertificate(caBlock.Bytes)
+					if err != nil {
+						return fmt.Errorf("error parsing ca cert: %s", err)
+					}
+					certPool := x509.NewCertPool()
+
+					// Verify certificate
+					_, err = cert.Verify(x509.VerifyOptions{Roots: certPool})
+					if err == nil {
+						return errors.New("incorrectly verified certificate")
+					} else if _, ok := err.(x509.UnknownAuthorityError); !ok {
+						return fmt.Errorf("incorrect verify error: expected UnknownAuthorityError, got %v", err)
+					}
+					certPool.AddCert(caCert)
+					if _, err = cert.Verify(x509.VerifyOptions{Roots: certPool}); err != nil {
+						return fmt.Errorf("verify failed: %s", err)
+					}
+
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func locallySignedCertConfig(validity, earlyRenewal uint32, setKeyAlgorithm bool) string {
+	caKeyAlgorithmCfg := ""
+	if setKeyAlgorithm {
+		caKeyAlgorithmCfg = `ca_key_algorithm = "RSA"`
+	}
+
 	return fmt.Sprintf(`
                     resource "tls_locally_signed_cert" "test" {
                         cert_request_pem = <<EOT
@@ -317,6 +453,7 @@ EOT
                         ca_cert_pem = <<EOT
 %s
 EOT
+                        %s
                         ca_private_key_pem = <<EOT
 %s
 EOT
@@ -324,5 +461,5 @@ EOT
                     output "cert_pem" {
                         value = "${tls_locally_signed_cert.test.cert_pem}"
                     }
-                `, testCertRequest, validity, earlyRenewal, testCACert, testCAPrivateKey)
+                `, testCertRequest, validity, earlyRenewal, testCACert, caKeyAlgorithmCfg, testCAPrivateKey)
 }

--- a/internal/provider/resource_locally_signed_cert_test.go
+++ b/internal/provider/resource_locally_signed_cert_test.go
@@ -314,7 +314,6 @@ EOT
                             "client_auth",
                         ]
 
-                        ca_key_algorithm = "RSA"
                         ca_cert_pem = <<EOT
 %s
 EOT

--- a/internal/provider/resource_private_key.go
+++ b/internal/provider/resource_private_key.go
@@ -132,7 +132,7 @@ func createResourcePrivateKey(d *schema.ResourceData, _ interface{}) error {
 	switch k := key.(type) {
 	case *rsa.PrivateKey:
 		keyPemBlock = &pem.Block{
-			Type:  PrivateKeyRSA.String(),
+			Type:  PreamblePrivateKeyRSA.String(),
 			Bytes: x509.MarshalPKCS1PrivateKey(k),
 		}
 	case *ecdsa.PrivateKey:
@@ -142,7 +142,7 @@ func createResourcePrivateKey(d *schema.ResourceData, _ interface{}) error {
 		}
 
 		keyPemBlock = &pem.Block{
-			Type:  PrivateKeyECDSA.String(),
+			Type:  PreamblePrivateKeyEC.String(),
 			Bytes: keyBytes,
 		}
 
@@ -157,7 +157,7 @@ func createResourcePrivateKey(d *schema.ResourceData, _ interface{}) error {
 		}
 
 		keyPemBlock = &pem.Block{
-			Type:  PrivateKeyED25519.String(),
+			Type:  PreamblePrivateKeyPKCS8.String(),
 			Bytes: keyBytes,
 		}
 	default:

--- a/internal/provider/resource_private_key.go
+++ b/internal/provider/resource_private_key.go
@@ -1,11 +1,8 @@
 package provider
 
 import (
-	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
@@ -13,58 +10,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/terraform-providers/terraform-provider-tls/internal/openssh"
 )
-
-// keyGenerator extracts data from the given *schema.ResourceData,
-// and generates a new public/private key-pair according to the
-// selected algorithm.
-type keyGenerator func(d *schema.ResourceData) (crypto.PrivateKey, error)
-
-// keyParser parses a private key from the given []byte,
-// according to the selected algorithm.
-type keyParser func([]byte) (crypto.PrivateKey, error)
-
-var keyGenerators = map[Algorithm]keyGenerator{
-	RSA: func(d *schema.ResourceData) (crypto.PrivateKey, error) {
-		rsaBits := d.Get("rsa_bits").(int)
-		return rsa.GenerateKey(rand.Reader, rsaBits)
-	},
-	ECDSA: func(d *schema.ResourceData) (crypto.PrivateKey, error) {
-		curve := ECDSACurve(d.Get("ecdsa_curve").(string))
-		switch curve {
-		case P224:
-			return ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
-		case P256:
-			return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		case P384:
-			return ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
-		case P521:
-			return ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
-		default:
-			return nil, fmt.Errorf("invalid ECDSA curve; supported values are: %v", SupportedECDSACurves())
-		}
-	},
-	ED25519: func(d *schema.ResourceData) (crypto.PrivateKey, error) {
-		_, key, err := ed25519.GenerateKey(rand.Reader)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate ED25519 key: %s", err)
-		}
-		return &key, err
-	},
-}
-
-var keyParsers = map[Algorithm]keyParser{
-	RSA: func(der []byte) (crypto.PrivateKey, error) {
-		return x509.ParsePKCS1PrivateKey(der)
-	},
-	ECDSA: func(der []byte) (crypto.PrivateKey, error) {
-		return x509.ParseECPrivateKey(der)
-	},
-	ED25519: func(der []byte) (crypto.PrivateKey, error) {
-		return x509.ParsePKCS8PrivateKey(der)
-	},
-}
 
 func resourcePrivateKey() *schema.Resource {
 	return &schema.Resource{

--- a/internal/provider/resource_self_signed_cert.go
+++ b/internal/provider/resource_self_signed_cert.go
@@ -28,7 +28,7 @@ func resourceSelfSignedCert() *schema.Resource {
 }
 
 func CreateSelfSignedCert(d *schema.ResourceData, meta interface{}) error {
-	key, err := parsePrivateKey(d, "private_key_pem", "key_algorithm")
+	key, _, err := parsePrivateKeyPEM([]byte(d.Get("private_key_pem").(string)))
 	if err != nil {
 		return err
 	}
@@ -69,5 +69,5 @@ func CreateSelfSignedCert(d *schema.ResourceData, meta interface{}) error {
 		cert.URIs = append(cert.URIs, uri)
 	}
 
-	return createCertificate(d, &cert, &cert, toPublicKey(key), key)
+	return createCertificate(d, &cert, &cert, privateKeyToPublicKey(key), key)
 }

--- a/internal/provider/resource_self_signed_cert.go
+++ b/internal/provider/resource_self_signed_cert.go
@@ -16,7 +16,7 @@ func resourceSelfSignedCert() *schema.Resource {
 	setCertificateSubjectSchema(s)
 
 	return &schema.Resource{
-		Create:        CreateSelfSignedCert,
+		Create:        createSelfSignedCert,
 		Delete:        deleteCertificate,
 		Read:          readCertificate,
 		Update:        updateCertificate,
@@ -27,10 +27,14 @@ func resourceSelfSignedCert() *schema.Resource {
 	}
 }
 
-func CreateSelfSignedCert(d *schema.ResourceData, meta interface{}) error {
-	key, _, err := parsePrivateKeyPEM([]byte(d.Get("private_key_pem").(string)))
+func createSelfSignedCert(d *schema.ResourceData, meta interface{}) error {
+	key, algorithm, err := parsePrivateKeyPEM([]byte(d.Get("private_key_pem").(string)))
 	if err != nil {
 		return err
+	}
+
+	if err := d.Set("key_algorithm", algorithm); err != nil {
+		return fmt.Errorf("error setting value on key 'key_algorithm': %s", err)
 	}
 
 	subjectConfs := d.Get("subject").([]interface{})

--- a/internal/provider/resource_self_signed_cert_test.go
+++ b/internal/provider/resource_self_signed_cert_test.go
@@ -129,7 +129,6 @@ func TestSelfSignedCert(t *testing.T) {
                         subject {
                             serial_number = "42"
                         }
-                        key_algorithm = "RSA"
                         validity_period_hours = 1
                         allowed_uses = []
                         private_key_pem = <<EOT
@@ -374,7 +373,6 @@ func TestAccSelfSignedCertSetSubjectKeyID(t *testing.T) {
 					subject {
 						serial_number = "42"
 					}
-					key_algorithm = "RSA"
 					validity_period_hours = 1
 					allowed_uses = []
 					set_subject_key_id = true
@@ -415,7 +413,6 @@ func TestAccSelfSignedCert_InvalidConfigs(t *testing.T) {
 						subject {
 							common_name = "common test cert"
 						}
-						key_algorithm = "RSA"
 						validity_period_hours = 1
 						allowed_uses = [
 							"not_valid"
@@ -435,7 +432,6 @@ func TestAccSelfSignedCert_InvalidConfigs(t *testing.T) {
 						subject {
 							common_name = "common test cert"
 						}
-						key_algorithm = "RSA"
 						validity_period_hours = -1
 						allowed_uses = [
 						]
@@ -454,7 +450,6 @@ func TestAccSelfSignedCert_InvalidConfigs(t *testing.T) {
 						subject {
 							common_name = "common test cert"
 						}
-						key_algorithm = "RSA"
 						validity_period_hours = 20
 						early_renewal_hours = -10
 						allowed_uses = [
@@ -512,7 +507,6 @@ func selfSignedCertConfig(validity uint32, earlyRenewal uint32) string {
                             "client_auth",
                         ]
 
-                        key_algorithm = "RSA"
                         private_key_pem = <<EOT
 %s
 EOT

--- a/internal/provider/resource_self_signed_cert_test.go
+++ b/internal/provider/resource_self_signed_cert_test.go
@@ -19,7 +19,7 @@ func TestSelfSignedCert(t *testing.T) {
 		Providers: testProviders,
 		Steps: []r.TestStep{
 			{
-				Config: selfSignedCertConfig(1, 0),
+				Config: selfSignedCertConfig(1, 0, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["key_pem_1"].Value
 					got, ok := gotUntyped.(string)
@@ -208,6 +208,120 @@ EOT
 	})
 }
 
+// TODO Remove this as part of https://github.com/hashicorp/terraform-provider-tls/issues/174
+func TestSelfSignedCert_HandleKeyAlgorithmDeprecation(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		Providers: testProviders,
+		Steps: []r.TestStep{
+			{
+				Config: selfSignedCertConfig(1, 0, true),
+				Check: func(s *terraform.State) error {
+					gotUntyped := s.RootModule().Outputs["key_pem_1"].Value
+					got, ok := gotUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"key_pem_1\" is not a string")
+					}
+
+					if !strings.HasPrefix(got, "-----BEGIN CERTIFICATE----") {
+						return fmt.Errorf("key is missing cert PEM preamble")
+					}
+					block, _ := pem.Decode([]byte(got))
+					cert, err := x509.ParseCertificate(block.Bytes)
+					if err != nil {
+						return fmt.Errorf("error parsing cert: %s", err)
+					}
+					if expected, got := "2", cert.Subject.SerialNumber; got != expected {
+						return fmt.Errorf("incorrect subject serial number: expected %v, got %v", expected, got)
+					}
+					if expected, got := "example.com", cert.Subject.CommonName; got != expected {
+						return fmt.Errorf("incorrect subject common name: expected %v, got %v", expected, got)
+					}
+					if expected, got := "Example, Inc", cert.Subject.Organization[0]; got != expected {
+						return fmt.Errorf("incorrect subject organization: expected %v, got %v", expected, got)
+					}
+					if expected, got := "Department of Terraform Testing", cert.Subject.OrganizationalUnit[0]; got != expected {
+						return fmt.Errorf("incorrect subject organizational unit: expected %v, got %v", expected, got)
+					}
+					if expected, got := "5879 Cotton Link", cert.Subject.StreetAddress[0]; got != expected {
+						return fmt.Errorf("incorrect subject street address: expected %v, got %v", expected, got)
+					}
+					if expected, got := "Pirate Harbor", cert.Subject.Locality[0]; got != expected {
+						return fmt.Errorf("incorrect subject locality: expected %v, got %v", expected, got)
+					}
+					if expected, got := "CA", cert.Subject.Province[0]; got != expected {
+						return fmt.Errorf("incorrect subject province: expected %v, got %v", expected, got)
+					}
+					if expected, got := "US", cert.Subject.Country[0]; got != expected {
+						return fmt.Errorf("incorrect subject country: expected %v, got %v", expected, got)
+					}
+					if expected, got := "95559-1227", cert.Subject.PostalCode[0]; got != expected {
+						return fmt.Errorf("incorrect subject postal code: expected %v, got %v", expected, got)
+					}
+
+					if expected, got := 2, len(cert.DNSNames); got != expected {
+						return fmt.Errorf("incorrect number of DNS names: expected %v, got %v", expected, got)
+					}
+					if expected, got := "example.com", cert.DNSNames[0]; got != expected {
+						return fmt.Errorf("incorrect DNS name 0: expected %v, got %v", expected, got)
+					}
+					if expected, got := "example.net", cert.DNSNames[1]; got != expected {
+						return fmt.Errorf("incorrect DNS name 0: expected %v, got %v", expected, got)
+					}
+
+					if expected, got := 2, len(cert.IPAddresses); got != expected {
+						return fmt.Errorf("incorrect number of IP addresses: expected %v, got %v", expected, got)
+					}
+					if expected, got := "127.0.0.1", cert.IPAddresses[0].String(); got != expected {
+						return fmt.Errorf("incorrect IP address 0: expected %v, got %v", expected, got)
+					}
+					if expected, got := "127.0.0.2", cert.IPAddresses[1].String(); got != expected {
+						return fmt.Errorf("incorrect IP address 0: expected %v, got %v", expected, got)
+					}
+
+					if expected, got := 2, len(cert.URIs); got != expected {
+						return fmt.Errorf("incorrect number of URIs: expected %v, got %v", expected, got)
+					}
+					if expected, got := "spiffe://example-trust-domain/ca", cert.URIs[0].String(); got != expected {
+						return fmt.Errorf("incorrect URI 0: expected %v, got %v", expected, got)
+					}
+					if expected, got := "spiffe://example-trust-domain/ca2", cert.URIs[1].String(); got != expected {
+						return fmt.Errorf("incorrect URI 1: expected %v, got %v", expected, got)
+					}
+
+					if expected, got := 2, len(cert.ExtKeyUsage); got != expected {
+						return fmt.Errorf("incorrect number of ExtKeyUsage: expected %v, got %v", expected, got)
+					}
+					if expected, got := x509.ExtKeyUsageServerAuth, cert.ExtKeyUsage[0]; got != expected {
+						return fmt.Errorf("incorrect ExtKeyUsage[0]: expected %v, got %v", expected, got)
+					}
+					if expected, got := x509.ExtKeyUsageClientAuth, cert.ExtKeyUsage[1]; got != expected {
+						return fmt.Errorf("incorrect ExtKeyUsage[1]: expected %v, got %v", expected, got)
+					}
+
+					if expected, got := x509.KeyUsageKeyEncipherment|x509.KeyUsageDigitalSignature, cert.KeyUsage; got != expected {
+						return fmt.Errorf("incorrect KeyUsage: expected %v, got %v", expected, got)
+					}
+
+					// This time checking is a bit sloppy to avoid inconsistent test results
+					// depending on the power of the machine running the tests.
+					now := time.Now()
+					if cert.NotBefore.After(now) {
+						return fmt.Errorf("certificate validity begins in the future")
+					}
+					if now.Sub(cert.NotBefore) > (2 * time.Minute) {
+						return fmt.Errorf("certificate validity begins more than two minutes in the past")
+					}
+					if cert.NotAfter.Sub(cert.NotBefore) != time.Hour {
+						return fmt.Errorf("certificate validity is not one hour")
+					}
+
+					return nil
+				},
+			},
+		},
+	})
+}
+
 func TestAccSelfSignedCertRecreatesAfterExpired(t *testing.T) {
 	oldNow := overridableTimeFunc
 	var previousCert string
@@ -216,7 +330,7 @@ func TestAccSelfSignedCertRecreatesAfterExpired(t *testing.T) {
 		PreCheck:  setTimeForTest("2019-06-14T12:00:00Z"),
 		Steps: []r.TestStep{
 			{
-				Config: selfSignedCertConfig(10, 2),
+				Config: selfSignedCertConfig(10, 2, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["key_pem_1"].Value
 					got, ok := gotUntyped.(string)
@@ -228,7 +342,7 @@ func TestAccSelfSignedCertRecreatesAfterExpired(t *testing.T) {
 				},
 			},
 			{
-				Config: selfSignedCertConfig(10, 2),
+				Config: selfSignedCertConfig(10, 2, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["key_pem_1"].Value
 					got, ok := gotUntyped.(string)
@@ -246,7 +360,7 @@ func TestAccSelfSignedCertRecreatesAfterExpired(t *testing.T) {
 			},
 			{
 				PreConfig: setTimeForTest("2019-06-14T19:00:00Z"),
-				Config:    selfSignedCertConfig(10, 2),
+				Config:    selfSignedCertConfig(10, 2, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["key_pem_1"].Value
 					got, ok := gotUntyped.(string)
@@ -264,7 +378,7 @@ func TestAccSelfSignedCertRecreatesAfterExpired(t *testing.T) {
 			},
 			{
 				PreConfig: setTimeForTest("2019-06-14T21:00:00Z"),
-				Config:    selfSignedCertConfig(10, 2),
+				Config:    selfSignedCertConfig(10, 2, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["key_pem_1"].Value
 					got, ok := gotUntyped.(string)
@@ -293,7 +407,7 @@ func TestAccSelfSignedCertNotRecreatedForEarlyRenewalUpdateInFuture(t *testing.T
 		PreCheck:  setTimeForTest("2019-06-14T12:00:00Z"),
 		Steps: []r.TestStep{
 			{
-				Config: selfSignedCertConfig(10, 2),
+				Config: selfSignedCertConfig(10, 2, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["key_pem_1"].Value
 					got, ok := gotUntyped.(string)
@@ -305,25 +419,7 @@ func TestAccSelfSignedCertNotRecreatedForEarlyRenewalUpdateInFuture(t *testing.T
 				},
 			},
 			{
-				Config: selfSignedCertConfig(10, 3),
-				Check: func(s *terraform.State) error {
-					gotUntyped := s.RootModule().Outputs["key_pem_1"].Value
-					got, ok := gotUntyped.(string)
-					if !ok {
-						return fmt.Errorf("output for \"key_pem_1\" is not a string")
-					}
-
-					if got != previousCert {
-						return fmt.Errorf("certificate updated even though still time until early renewal")
-					}
-
-					previousCert = got
-					return nil
-				},
-			},
-			{
-				PreConfig: setTimeForTest("2019-06-14T16:00:00Z"),
-				Config:    selfSignedCertConfig(10, 3),
+				Config: selfSignedCertConfig(10, 3, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["key_pem_1"].Value
 					got, ok := gotUntyped.(string)
@@ -341,7 +437,25 @@ func TestAccSelfSignedCertNotRecreatedForEarlyRenewalUpdateInFuture(t *testing.T
 			},
 			{
 				PreConfig: setTimeForTest("2019-06-14T16:00:00Z"),
-				Config:    selfSignedCertConfig(10, 9),
+				Config:    selfSignedCertConfig(10, 3, false),
+				Check: func(s *terraform.State) error {
+					gotUntyped := s.RootModule().Outputs["key_pem_1"].Value
+					got, ok := gotUntyped.(string)
+					if !ok {
+						return fmt.Errorf("output for \"key_pem_1\" is not a string")
+					}
+
+					if got != previousCert {
+						return fmt.Errorf("certificate updated even though still time until early renewal")
+					}
+
+					previousCert = got
+					return nil
+				},
+			},
+			{
+				PreConfig: setTimeForTest("2019-06-14T16:00:00Z"),
+				Config:    selfSignedCertConfig(10, 9, false),
 				Check: func(s *terraform.State) error {
 					gotUntyped := s.RootModule().Outputs["key_pem_1"].Value
 					got, ok := gotUntyped.(string)
@@ -467,7 +581,12 @@ func TestAccSelfSignedCert_InvalidConfigs(t *testing.T) {
 	})
 }
 
-func selfSignedCertConfig(validity uint32, earlyRenewal uint32) string {
+func selfSignedCertConfig(validity, earlyRenewal uint32, setKeyAlgorithm bool) string {
+	keyAlgorithmCfg := ""
+	if setKeyAlgorithm {
+		keyAlgorithmCfg = `key_algorithm = "RSA"`
+	}
+
 	return fmt.Sprintf(`
                     resource "tls_self_signed_cert" "test1" {
                         subject {
@@ -507,6 +626,7 @@ func selfSignedCertConfig(validity uint32, earlyRenewal uint32) string {
                             "client_auth",
                         ]
 
+                        %s
                         private_key_pem = <<EOT
 %s
 EOT
@@ -514,5 +634,5 @@ EOT
                     output "key_pem_1" {
                         value = tls_self_signed_cert.test1.cert_pem
                     }
-                `, validity, earlyRenewal, testPrivateKeyPEM)
+                `, validity, earlyRenewal, keyAlgorithmCfg, testPrivateKeyPEM)
 }

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -1,10 +1,6 @@
 package provider
 
 import (
-	"crypto"
-	"crypto/ecdsa"
-	"crypto/ed25519"
-	"crypto/rsa"
 	"fmt"
 )
 
@@ -38,20 +34,6 @@ func SupportedAlgorithmsStr() []string {
 		supportedStr[i] = string(supported[i])
 	}
 	return supportedStr
-}
-
-// PrivateKeyToAlgorithm identifies the Algorithm used by a given crypto.PrivateKey.
-func PrivateKeyToAlgorithm(prvKey crypto.PrivateKey) (Algorithm, error) {
-	switch k := prvKey.(type) {
-	case *rsa.PrivateKey:
-		return RSA, nil
-	case *ecdsa.PrivateKey:
-		return ECDSA, nil
-	case *ed25519.PrivateKey:
-		return ED25519, nil
-	default:
-		return "", fmt.Errorf("failed to identify key algorithm for unsupported private key: %#v", k)
-	}
 }
 
 // ECDSACurve represents a type of ECDSA elliptic curve.

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"encoding/pem"
 	"fmt"
 )
 
@@ -70,53 +71,43 @@ func SupportedECDSACurvesStr() []string {
 	return supportedStr
 }
 
-// PEMPreamblePrivateKey represents the "type" heading used by a PEM-formatted Private Key.
-// See: https://datatracker.ietf.org/doc/html/rfc1421
-type PEMPreamblePrivateKey string
+// PEMPreamble represents the heading used in a PEM-formatted for the "encapsulation boundaries",
+// that is used to delimit the "encapsulated text portion" of cryptographic documents.
+//
+// See https://datatracker.ietf.org/doc/html/rfc1421 and https://datatracker.ietf.org/doc/html/rfc7468.
+type PEMPreamble string
 
 const (
-	PrivateKeyRSA     PEMPreamblePrivateKey = "RSA PRIVATE KEY"
-	PrivateKeyECDSA   PEMPreamblePrivateKey = "EC PRIVATE KEY"
-	PrivateKeyED25519 PEMPreamblePrivateKey = "PRIVATE KEY"
+	PreamblePublicKey PEMPreamble = "PUBLIC KEY"
+
+	PreamblePrivateKeyPKCS8 PEMPreamble = "PRIVATE KEY"
+	PreamblePrivateKeyRSA   PEMPreamble = "RSA PRIVATE KEY"
+	PreamblePrivateKeyEC    PEMPreamble = "EC PRIVATE KEY"
+
+	PreambleCertificate        PEMPreamble = "CERTIFICATE"
+	PreambleCertificateRequest PEMPreamble = "CERTIFICATE REQUEST"
 )
 
-func (p PEMPreamblePrivateKey) String() string {
+func (p PEMPreamble) String() string {
 	return string(p)
 }
 
-func (p PEMPreamblePrivateKey) Algorithm() (Algorithm, error) {
-	switch p {
-	case PrivateKeyRSA:
-		return RSA, nil
-	case PrivateKeyECDSA:
-		return ECDSA, nil
-	case PrivateKeyED25519:
-		return ED25519, nil
+// PEMBlockToPEMPreamble takes a pem.Block and returns the related PEMPreamble, if supported.
+func PEMBlockToPEMPreamble(block *pem.Block) (PEMPreamble, error) {
+	switch block.Type {
+	case PreamblePublicKey.String():
+		return PreamblePublicKey, nil
+	case PreamblePrivateKeyPKCS8.String():
+		return PreamblePrivateKeyPKCS8, nil
+	case PreamblePrivateKeyRSA.String():
+		return PreamblePrivateKeyRSA, nil
+	case PreamblePrivateKeyEC.String():
+		return PreamblePrivateKeyEC, nil
+	case PreambleCertificate.String():
+		return PreambleCertificate, nil
+	case PreambleCertificateRequest.String():
+		return PreambleCertificateRequest, nil
 	default:
-		return "", fmt.Errorf("unknown PEM preamble for private key: %#v", p)
+		return "", fmt.Errorf("unsupported PEM preamble/type: %s", block.Type)
 	}
-}
-
-// PEMPreamblePublicKey represents the "type" heading used by a PEM-formatted Public Key.
-// See: https://datatracker.ietf.org/doc/html/rfc1421
-type PEMPreamblePublicKey string
-
-const (
-	PublicKey PEMPreamblePrivateKey = "PUBLIC KEY"
-)
-
-func (p PEMPreamblePublicKey) String() string {
-	return string(p)
-}
-
-// PEMPreambleCertificate represents the heading used by Certificates and related PEM-formatted files.
-type PEMPreambleCertificate string
-
-const (
-	Certificate        PEMPreambleCertificate = "CERTIFICATE"
-	CertificateRequest PEMPreambleCertificate = "CERTIFICATE REQUEST"
-)
-
-func (c PEMPreambleCertificate) String() string {
-	return string(c)
 }

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -1,12 +1,7 @@
 package provider
 
 import (
-	"crypto"
-	"crypto/ecdsa"
-	"crypto/ed25519"
-	"crypto/rsa"
 	"crypto/sha1"
-	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
@@ -14,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"golang.org/x/crypto/ssh"
 )
 
 func decodePEM(d *schema.ResourceData, pemKey, pemType string) (*pem.Block, error) {
@@ -27,137 +21,6 @@ func decodePEM(d *schema.ResourceData, pemKey, pemType string) (*pem.Block, erro
 	}
 
 	return block, nil
-}
-
-func parsePrivateKey(d *schema.ResourceData, pemKey, algoKey string) (crypto.PrivateKey, error) {
-	algoName := Algorithm(d.Get(algoKey).(string))
-
-	parser, ok := keyParsers[algoName]
-	if !ok {
-		return nil, fmt.Errorf("invalid %s: %#v", algoKey, algoName)
-	}
-
-	block, err := decodePEM(d, pemKey, "")
-	if err != nil {
-		return nil, err
-	}
-
-	key, err := parser(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode %s: %s", pemKey, err)
-	}
-
-	return key, nil
-}
-
-func parseCertificate(d *schema.ResourceData, pemKey string) (*x509.Certificate, error) {
-	block, err := decodePEM(d, pemKey, "")
-	if err != nil {
-		return nil, err
-	}
-
-	certs, err := x509.ParseCertificates(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse %s: %s", pemKey, err)
-	}
-	if len(certs) < 1 {
-		return nil, fmt.Errorf("no certificates found in %s", pemKey)
-	}
-	if len(certs) > 1 {
-		return nil, fmt.Errorf("multiple certificates found in %s", pemKey)
-	}
-
-	return certs[0], nil
-}
-
-func parseCertificateRequest(d *schema.ResourceData, pemKey string) (*x509.CertificateRequest, error) {
-	block, err := decodePEM(d, pemKey, CertificateRequest.String())
-	if err != nil {
-		return nil, err
-	}
-
-	certReq, err := x509.ParseCertificateRequest(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse %s: %s", pemKey, err)
-	}
-
-	return certReq, nil
-}
-
-func certificateToMap(cert *x509.Certificate) map[string]interface{} {
-	return map[string]interface{}{
-		"signature_algorithm":  cert.SignatureAlgorithm.String(),
-		"public_key_algorithm": cert.PublicKeyAlgorithm.String(),
-		"serial_number":        cert.SerialNumber.String(),
-		"is_ca":                cert.IsCA,
-		"version":              cert.Version,
-		"issuer":               cert.Issuer.String(),
-		"subject":              cert.Subject.String(),
-		"not_before":           cert.NotBefore.Format(time.RFC3339),
-		"not_after":            cert.NotAfter.Format(time.RFC3339),
-		"sha1_fingerprint":     fmt.Sprintf("%x", sha1.Sum(cert.Raw)),
-	}
-}
-
-// setPublicKeyAttributes takes a crypto.PrivateKey, extracts the corresponding crypto.PublicKey and then
-// encodes related attributes on the given schema.ResourceData.
-func setPublicKeyAttributes(d *schema.ResourceData, prvKey crypto.PrivateKey) error {
-	pubKey := toPublicKey(prvKey)
-	pubKeyBytes, err := x509.MarshalPKIXPublicKey(pubKey)
-	if err != nil {
-		return fmt.Errorf("failed to marshal public key error: %s", err)
-	}
-	pubKeyPemBlock := &pem.Block{
-		Type:  PublicKey.String(),
-		Bytes: pubKeyBytes,
-	}
-
-	d.SetId(hashForState(string(pubKeyBytes)))
-
-	if err := d.Set("public_key_pem", string(pem.EncodeToMemory(pubKeyPemBlock))); err != nil {
-		return fmt.Errorf("error setting value on key 'public_key_pem': %s", err)
-	}
-
-	// NOTE: ECDSA keys with elliptic curve P-224 are not supported by `x/crypto/ssh`,
-	// so this will return an error: in that case, we set the below fields to emptry strings
-	sshPubKey, err := ssh.NewPublicKey(toPublicKey(prvKey))
-	var pubKeySSH, pubKeySSHFingerprintMD5, pubKeySSHFingerprintSHA256 string
-	if err == nil {
-		sshPubKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
-
-		pubKeySSH = string(sshPubKeyBytes)
-		pubKeySSHFingerprintMD5 = ssh.FingerprintLegacyMD5(sshPubKey)
-		pubKeySSHFingerprintSHA256 = ssh.FingerprintSHA256(sshPubKey)
-	}
-
-	if err := d.Set("public_key_openssh", pubKeySSH); err != nil {
-		return fmt.Errorf("error setting value on key 'public_key_openssh': %s", err)
-	}
-
-	if err := d.Set("public_key_fingerprint_md5", pubKeySSHFingerprintMD5); err != nil {
-		return fmt.Errorf("error setting value on key 'public_key_fingerprint_md5': %s", err)
-	}
-
-	if err := d.Set("public_key_fingerprint_sha256", pubKeySSHFingerprintSHA256); err != nil {
-		return fmt.Errorf("error setting value on key 'public_key_fingerprint_sha256': %s", err)
-	}
-
-	return nil
-}
-
-// toPublicKey takes a crypto.PrivateKey and extracts the corresponding crypto.PublicKey,
-// after having figured out its type.
-func toPublicKey(prvKey crypto.PrivateKey) crypto.PublicKey {
-	switch k := prvKey.(type) {
-	case *rsa.PrivateKey:
-		return &k.PublicKey
-	case *ecdsa.PrivateKey:
-		return &k.PublicKey
-	case *ed25519.PrivateKey:
-		return k.Public()
-	default:
-		return nil
-	}
 }
 
 // hashForState computes the hexadecimal representation of the SHA1 checksum of a string.


### PR DESCRIPTION
Context: #150

By moving all the utilities related to `*_cert` in `common_cert.go`, and doing the same for `*.key`, it is now easy to have the same support for Key Algorithm across the board.

With this, all the certs support ED25519 private keys, without any code specific for this in their implementation.

Additionally, the fields `*_key_algorithm` used in the `*_cert` resources are now all marked as `Optional` and `Deprecated`: the plan is to release 3.2.0 first, then change those fields to `Computed` (i.e. exposing the inferred algorithm), and then release a 4.0.0. This (should be) in accordance with our guidelines: https://www.terraform.io/plugin/sdkv2/best-practices/deprecations.

### How the "deprecation" of `*_key_algorithm` looks like

#### Today 

```
"key_algorithm": &schema.Schema{
  Type:     schema.TypeString,
  Required: true,
  ForceNew: true,
```

#### 3.2.0 (i.e. this PR)

```
"key_algorithm": &schema.Schema{
  Type:       schema.TypeString,
  Optional:   true,
  ForceNew:   true,
  Deprecated: "DEPRECATION MESSAGE"
```

This will:

1. inform user with a warning that the field should not be used anymore
2. if the user complies, the state gets updated with the removal of the string from it

At this point, we release 3.2.0

#### 4.0.0 (future PR)

```
"key_algorithm": &schema.Schema{
  Type:       schema.TypeString,
  Computed:   true,
```

This will:

1. allow the provider to `.Set("key_algorithm")`
2. the state is updated with the computed value