### PR TITLE
Relaxing validation of `allowed_uses` in `tls_locally_signed_cert` and `tls_self_signed_cert`

### DIFF
--- a/internal/provider/common_cert.go
+++ b/internal/provider/common_cert.go
@@ -270,7 +270,7 @@ func setCertificateCommonSchema(s map[string]*schema.Schema) {
 		ForceNew: true,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
-			ValidateFunc: validation.StringInSlice(supportedKeyUsages(), false),
+			ValidateFunc: StringInSliceOrWarn(supportedKeyUsages(), false),
 		},
 		Description: "List of key usages allowed for the issued certificate. " +
 			"Values are defined in [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280) " +
@@ -527,5 +527,29 @@ func certificateToMap(cert *x509.Certificate) map[string]interface{} {
 		"not_before":           cert.NotBefore.Format(time.RFC3339),
 		"not_after":            cert.NotAfter.Format(time.RFC3339),
 		"sha1_fingerprint":     fmt.Sprintf("%x", sha1.Sum(cert.Raw)),
+	}
+}
+
+// StringInSliceOrWarn returns a SchemaValidateFunc which tests if the provided value
+// is of type string and matches the value of an element in the valid slice.
+//
+// Differently from validation.StringInSlice, if the element is not part of the valid slice,
+// a warning is produced.
+func StringInSliceOrWarn(valid []string, ignoreCase bool) schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+			return warnings, errors
+		}
+
+		for _, str := range valid {
+			if v == str || (ignoreCase && strings.EqualFold(v, str)) {
+				return warnings, errors
+			}
+		}
+
+		warnings = append(warnings, fmt.Sprintf("expected %s to be one of %v, got %s so will ignored", k, valid, v))
+		return warnings, errors
 	}
 }

--- a/internal/provider/common_cert.go
+++ b/internal/provider/common_cert.go
@@ -269,8 +269,8 @@ func setCertificateCommonSchema(s map[string]*schema.Schema) {
 		Required: true,
 		ForceNew: true,
 		Elem: &schema.Schema{
-			Type:         schema.TypeString,
-			ValidateFunc: StringInSliceOrWarn(supportedKeyUsages(), false),
+			Type:             schema.TypeString,
+			ValidateDiagFunc: StringInSliceOrWarn(supportedKeyUsages(), false),
 		},
 		Description: "List of key usages allowed for the issued certificate. " +
 			"Values are defined in [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280) " +
@@ -535,8 +535,8 @@ func certificateToMap(cert *x509.Certificate) map[string]interface{} {
 //
 // Differently from validation.StringInSlice, if the element is not part of the valid slice,
 // a warning is produced.
-func StringInSliceOrWarn(valid []string, ignoreCase bool) schema.SchemaValidateFunc {
-	return func(i interface{}, k string) (warnings []string, errors []error) {
+func StringInSliceOrWarn(valid []string, ignoreCase bool) schema.SchemaValidateDiagFunc {
+	return validation.ToDiagFunc(func(i interface{}, k string) (warnings []string, errors []error) {
 		v, ok := i.(string)
 		if !ok {
 			errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
@@ -551,5 +551,5 @@ func StringInSliceOrWarn(valid []string, ignoreCase bool) schema.SchemaValidateF
 
 		warnings = append(warnings, fmt.Sprintf("expected %s to be one of %v, got %s so will ignored", k, valid, v))
 		return warnings, errors
-	}
+	})
 }

--- a/internal/provider/resource_self_signed_cert_test.go
+++ b/internal/provider/resource_self_signed_cert_test.go
@@ -527,25 +527,6 @@ func TestAccSelfSignedCert_InvalidConfigs(t *testing.T) {
 						subject {
 							common_name = "common test cert"
 						}
-						validity_period_hours = 1
-						allowed_uses = [
-							"not_valid"
-						]
-						set_subject_key_id = true
-						private_key_pem = "does not matter"
-					}
-					output "cert_pem" {
-						value = tls_self_signed_cert.test.cert_pem
-					}
-				`,
-				ExpectError: regexp.MustCompile(`expected allowed_uses.0 to be one of \[.*\], got not_valid`),
-			},
-			{
-				Config: `
-					resource "tls_self_signed_cert" "test" {
-						subject {
-							common_name = "common test cert"
-						}
 						validity_period_hours = -1
 						allowed_uses = [
 						]
@@ -624,6 +605,7 @@ func selfSignedCertConfig(validity, earlyRenewal uint32, setKeyAlgorithm bool) s
                             "digital_signature",
                             "server_auth",
                             "client_auth",
+                            "non_repudiation",
                         ]
 
                         %s


### PR DESCRIPTION
As part of [milestone 3.2.0](https://github.com/hashicorp/terraform-provider-tls/milestone/1), more stringent validation was introduced in many arguments fields. One of which is the argument `allowed_uses`, used by the resources:

* `tls_locally_signed_cert`
* `tls_self_signed_cert`

Given the nature of the argument, values provided that were not known to the Provider code, were silently ignored: the practitioner would get a certificate without one or more of the [Key Usages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3) they expected, but the provider would not report it.

Hence, the introduction of the validation.

Unfortunately this means that existing terraform configurations started failing with the update to 3.2.0. 

So, in the interest of not introducing regressions, this PR alters the validation logic slightly: if practitioner uses a non acceptable value for `allowed_uses`, instead of erroring, **the provider will raise a warning and ignore the specific erroneous argument**.