### PR TITLE
CI to build against both 1.17 and 1.18 for future-proofing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,17 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 5
+
+    strategy:
+      matrix:
+        go-version: [ '1.18', '1.17' ]
+
     steps:
 
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: ${{ matrix.go-version }}
         check-latest: true
 
     - name: Check out code
@@ -52,6 +57,7 @@ jobs:
     needs: build
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+
     strategy:
       fail-fast: false
       matrix:
@@ -66,6 +72,7 @@ jobs:
           - '0.15.*'
           - '1.0.*'
           - '1.1.*'
+
     steps:
 
     - name: Setup Go


### PR DESCRIPTION
Context: https://github.com/hashicorp/terraform-provider-tls/issues/188#issuecomment-1123404375