### PR TITLE
Allow empty or absent `subject` block

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,3 +15,6 @@ linters:
     - tenv
     - unconvert
     - unparam
+
+run:
+  allow-parallel-runners: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ BUG FIXES:
 
 * data-source/tls_certificate: Prevent plan differences with the `id` attribute ([#79](https://github.com/hashicorp/terraform-provider-tls/issues/79), [#189](https://github.com/hashicorp/terraform-provider-tls/pull/189)).
 
+* resource/tls_cert_request: Allow for absent or empty `subject` block ([#209](https://github.com/hashicorp/terraform-provider-tls/pull/209))
+
+* resource/tls_self_signed_cert: Allow for absent or empty `subject` block ([#209](https://github.com/hashicorp/terraform-provider-tls/pull/209))
+
 ## 3.3.0 (April 07, 2022)
 
 NEW FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ NEW FEATURES:
 * data-source/tls_certificate: New attribute `content` that can be used in alternative to `url`, to provide the certificate in PEM format ([#189](https://github.com/hashicorp/terraform-provider-tls/pull/189)).
 * data-source/tls_certificate: Objects in the `certificates` chain attribute expose a new attribute `cert_pem` (PEM format) ([#208](https://github.com/hashicorp/terraform-provider-tls/pull/208)).
 
+ENHANCEMENTS:
+
+* resource/tls_locally_signed_cert: If CA provided via `ca_cert_pem` is not an actual CA, a warning will be raised, but the certificate will still be created ([#209](https://github.com/hashicorp/terraform-provider-tls/pull/209)). 
+
 NOTES:
 
 * data-source/tls_certificate: The `id` attribute has changed to the hashing of all certificates information in the chain. The first apply of this updated data source may show this difference ([#189](https://github.com/hashicorp/terraform-provider-tls/pull/189)).
@@ -13,9 +17,9 @@ BUG FIXES:
 
 * data-source/tls_certificate: Prevent plan differences with the `id` attribute ([#79](https://github.com/hashicorp/terraform-provider-tls/issues/79), [#189](https://github.com/hashicorp/terraform-provider-tls/pull/189)).
 
-* resource/tls_cert_request: Allow for absent or empty `subject` block ([#209](https://github.com/hashicorp/terraform-provider-tls/pull/209))
+* resource/tls_cert_request: Allow for absent or empty `subject` block ([#209](https://github.com/hashicorp/terraform-provider-tls/pull/209)).
 
-* resource/tls_self_signed_cert: Allow for absent or empty `subject` block ([#209](https://github.com/hashicorp/terraform-provider-tls/pull/209))
+* resource/tls_self_signed_cert: Allow for absent or empty `subject` block ([#209](https://github.com/hashicorp/terraform-provider-tls/pull/209)).
 
 ## 3.3.0 (April 07, 2022)
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,6 +8,7 @@ install: build
 
 # See https://golangci-lint.run/
 lint:
+	golangci-lint cache clean
 	golangci-lint run
 
 generate:

--- a/docs/resources/cert_request.md
+++ b/docs/resources/cert_request.md
@@ -38,13 +38,13 @@ resource "tls_cert_request" "example" {
 ### Required
 
 - `private_key_pem` (String, Sensitive) Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, that the certificate will belong to. This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file) interpolation function. Only an irreversible secure hash of the private key will be stored in the Terraform state.
-- `subject` (Block List, Min: 1) The subject for which a certificate is being requested. The acceptable arguments are all optional and their naming is based upon [Issuer Distinguished Names (RFC5280)](https://tools.ietf.org/html/rfc5280#section-4.1.2.4) section. (see [below for nested schema](#nestedblock--subject))
 
 ### Optional
 
 - `dns_names` (List of String) List of DNS names for which a certificate is being requested (i.e. certificate subjects).
 - `ip_addresses` (List of String) List of IP addresses for which a certificate is being requested (i.e. certificate subjects).
 - `key_algorithm` (String, Deprecated) Name of the algorithm used when generating the private key provided in `private_key_pem`. **NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key.
+- `subject` (Block List, Max: 1) The subject for which a certificate is being requested. The acceptable arguments are all optional and their naming is based upon [Issuer Distinguished Names (RFC5280)](https://tools.ietf.org/html/rfc5280#section-4.1.2.4) section. (see [below for nested schema](#nestedblock--subject))
 - `uris` (List of String) List of URIs for which a certificate is being requested (i.e. certificate subjects).
 
 ### Read-Only

--- a/docs/resources/self_signed_cert.md
+++ b/docs/resources/self_signed_cert.md
@@ -43,7 +43,6 @@ resource "tls_self_signed_cert" "example" {
 
 - `allowed_uses` (List of String) List of key usages allowed for the issued certificate. Values are defined in [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280) and combine flags defined by both [Key Usages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3) and [Extended Key Usages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12). Accepted values: `any_extended`, `cert_signing`, `client_auth`, `code_signing`, `content_commitment`, `crl_signing`, `data_encipherment`, `decipher_only`, `digital_signature`, `email_protection`, `encipher_only`, `ipsec_end_system`, `ipsec_tunnel`, `ipsec_user`, `key_agreement`, `key_encipherment`, `microsoft_commercial_code_signing`, `microsoft_kernel_code_signing`, `microsoft_server_gated_crypto`, `netscape_server_gated_crypto`, `ocsp_signing`, `server_auth`, `timestamping`.
 - `private_key_pem` (String, Sensitive) Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, that the certificate will belong to. This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file) interpolation function. Only an irreversible secure hash of the private key will be stored in the Terraform state.
-- `subject` (Block List, Min: 1) The subject for which a certificate is being requested. The acceptable arguments are all optional and their naming is based upon [Issuer Distinguished Names (RFC5280)](https://tools.ietf.org/html/rfc5280#section-4.1.2.4) section. (see [below for nested schema](#nestedblock--subject))
 - `validity_period_hours` (Number) Number of hours, after initial issuing, that the certificate will remain valid for.
 
 ### Optional
@@ -54,6 +53,7 @@ resource "tls_self_signed_cert" "example" {
 - `is_ca_certificate` (Boolean) Is the generated certificate representing a Certificate Authority (CA) (default: `false`).
 - `key_algorithm` (String, Deprecated) Name of the algorithm used when generating the private key provided in `private_key_pem`. **NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key.
 - `set_subject_key_id` (Boolean) Should the generated certificate include a [subject key identifier](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2) (default: `false`).
+- `subject` (Block List, Max: 1) The subject for which a certificate is being requested. The acceptable arguments are all optional and their naming is based upon [Issuer Distinguished Names (RFC5280)](https://tools.ietf.org/html/rfc5280#section-4.1.2.4) section. (see [below for nested schema](#nestedblock--subject))
 - `uris` (List of String) List of URIs for which a certificate is being requested (i.e. certificate subjects).
 
 ### Read-Only

--- a/internal/provider/common_cert.go
+++ b/internal/provider/common_cert.go
@@ -456,11 +456,9 @@ func updateCertificate(_ context.Context, _ *schema.ResourceData, _ interface{})
 	return nil
 }
 
-// getSubjectDistinguishedNames it looks for the "subject" attribute: if found and non-empty, it returns
-// a *pkix.Name useful for creating x509.Certificate or x509.CertificateRequest.
-func getSubjectDistinguishedNames(d *schema.ResourceData) *pkix.Name {
-	subjectList := d.Get("subject").([]interface{})
-
+// createSubjectDistinguishedNames return a *pkix.Name (i.e. a "Certificate Subject") if the non-empty.
+// This used for creating x509.Certificate or x509.CertificateRequest.
+func createSubjectDistinguishedNames(subjectList []interface{}) *pkix.Name {
 	if len(subjectList) == 0 {
 		// No subject block was provided
 		return nil

--- a/internal/provider/common_cert.go
+++ b/internal/provider/common_cert.go
@@ -164,8 +164,9 @@ func setCertificateSubjectSchema(s map[string]*schema.Schema) {
 
 	s["subject"] = &schema.Schema{
 		Type:     schema.TypeList,
-		Required: true,
+		Optional: true,
 		ForceNew: true,
+		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"organization": {

--- a/internal/provider/common_cert.go
+++ b/internal/provider/common_cert.go
@@ -451,18 +451,18 @@ func updateCertificate(_ context.Context, _ *schema.ResourceData, _ interface{})
 
 // getSubjectDistinguishedNames it looks for the "subject" attribute: if found and non-empty, it returns
 // a *pkix.Name useful for creating x509.Certificate or x509.CertificateRequest.
-func getSubjectDistinguishedNames(d *schema.ResourceData) (*pkix.Name, error) {
+func getSubjectDistinguishedNames(d *schema.ResourceData) *pkix.Name {
 	subjectList := d.Get("subject").([]interface{})
 
 	if len(subjectList) == 0 {
 		// No subject block was provided
-		return nil, nil
+		return nil
 	}
 
 	subject, ok := subjectList[0].(map[string]interface{})
 	if !ok {
 		// Empty subject block was provided
-		return nil, nil
+		return nil
 	}
 
 	result := &pkix.Name{}
@@ -498,7 +498,7 @@ func getSubjectDistinguishedNames(d *schema.ResourceData) (*pkix.Name, error) {
 		result.SerialNumber = value.(string)
 	}
 
-	return result, nil
+	return result
 }
 
 func parseCertificate(d *schema.ResourceData, pemKey string) (*x509.Certificate, error) {

--- a/internal/provider/resource_cert_request.go
+++ b/internal/provider/resource_cert_request.go
@@ -60,18 +60,16 @@ func createCertRequest(_ context.Context, d *schema.ResourceData, _ interface{})
 		return diag.Errorf("error setting value on key 'key_algorithm': %s", err)
 	}
 
-	subjectConfs := d.Get("subject").([]interface{})
-	if len(subjectConfs) != 1 {
-		return diag.Errorf("must have exactly one 'subject' block")
+	// Look for a 'subject' block
+	subject, err := getSubjectDistinguishedNames(d)
+	if err != nil {
+		return diag.FromErr(err)
 	}
-	subjectConf, ok := subjectConfs[0].(map[string]interface{})
-	if !ok {
-		return diag.Errorf("subject block cannot be empty")
-	}
-	subject := distinguishedNamesFromSubjectAttributes(subjectConf)
 
-	certReq := x509.CertificateRequest{
-		Subject: *subject,
+	// Add a `Subject` to the `Certificate` only if it was provided
+	certReq := x509.CertificateRequest{}
+	if subject != nil {
+		certReq.Subject = *subject
 	}
 
 	dnsNamesI := d.Get("dns_names").([]interface{})

--- a/internal/provider/resource_cert_request.go
+++ b/internal/provider/resource_cert_request.go
@@ -61,10 +61,7 @@ func createCertRequest(_ context.Context, d *schema.ResourceData, _ interface{})
 	}
 
 	// Look for a 'subject' block
-	subject, err := getSubjectDistinguishedNames(d)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	subject := getSubjectDistinguishedNames(d)
 
 	// Add a `Subject` to the `Certificate` only if it was provided
 	certReq := x509.CertificateRequest{}

--- a/internal/provider/resource_cert_request.go
+++ b/internal/provider/resource_cert_request.go
@@ -61,7 +61,7 @@ func createCertRequest(_ context.Context, d *schema.ResourceData, _ interface{})
 	}
 
 	// Look for a 'subject' block
-	subject := getSubjectDistinguishedNames(d)
+	subject := createSubjectDistinguishedNames(d.Get("subject").([]interface{}))
 
 	// Add a `Subject` to the `Certificate` only if it was provided
 	certReq := x509.CertificateRequest{}

--- a/internal/provider/resource_cert_request_test.go
+++ b/internal/provider/resource_cert_request_test.go
@@ -249,7 +249,7 @@ func TestAccResourceCertRequest_InvalidConfigs(t *testing.T) {
 						private_key_pem = tls_private_key.test.private_key_pem
                     }
                 `,
-				ExpectError: regexp.MustCompile("Too many subject blocks"),
+				ExpectError: regexp.MustCompile("Too many (list items|subject blocks)"),
 			},
 		},
 	})

--- a/internal/provider/resource_cert_request_test.go
+++ b/internal/provider/resource_cert_request_test.go
@@ -170,6 +170,7 @@ func TestAccResourceCertRequest_NoSubject(t *testing.T) {
                 `,
 				Check: r.ComposeAggregateTestCheckFunc(
 					testCheckPEMFormat("tls_cert_request.test", "cert_request_pem", PreambleCertificateRequest),
+					testCheckPEMCertificateRequestNoSubject("tls_cert_request.test", "cert_request_pem"),
 					testCheckPEMCertificateRequestDNSNames("tls_cert_request.test", "cert_request_pem", []string{
 						"pippo.pluto.paperino",
 					}),
@@ -206,6 +207,7 @@ func TestAccResourceCertRequest_NoSubject(t *testing.T) {
                 `,
 				Check: r.ComposeAggregateTestCheckFunc(
 					testCheckPEMFormat("tls_cert_request.test", "cert_request_pem", PreambleCertificateRequest),
+					testCheckPEMCertificateRequestNoSubject("tls_cert_request.test", "cert_request_pem"),
 					testCheckPEMCertificateRequestDNSNames("tls_cert_request.test", "cert_request_pem", []string{
 						"pippo.pluto.paperino",
 					}),

--- a/internal/provider/resource_cert_request_test.go
+++ b/internal/provider/resource_cert_request_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"crypto/x509/pkix"
-	"fmt"
 	"net"
 	"net/url"
 	"regexp"
@@ -83,7 +82,7 @@ func TestAccResourceCertRequest(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(`
+				Config: `
 					resource "tls_private_key" "test2" {
 						algorithm = "ED25519"
 					}
@@ -93,7 +92,7 @@ func TestAccResourceCertRequest(t *testing.T) {
 						}
 						private_key_pem = tls_private_key.test2.private_key_pem
 					}
-                `),
+                `,
 				Check: r.ComposeAggregateTestCheckFunc(
 					testCheckPEMFormat("tls_cert_request.test2", "cert_request_pem", PreambleCertificateRequest),
 					testCheckPEMCertificateRequestSubject("tls_cert_request.test2", "cert_request_pem", &pkix.Name{

--- a/internal/provider/resource_locally_signed_cert.go
+++ b/internal/provider/resource_locally_signed_cert.go
@@ -94,8 +94,8 @@ func createLocallySignedCert(_ context.Context, d *schema.ResourceData, _ interf
 	if !caCert.IsCA {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Warning,
-			Summary:  "CA is not a CA",
-			Detail:   "Certificate provided as Authority does not appear to be as much: the resulting certificate might fail validations",
+			Summary:  "Potentially Invalid Certificate Authority",
+			Detail:   "Certificate provided as Authority does not appear to be a valid Certificate Authority. The resulting certificate might fail certificate validation.",
 		})
 	}
 

--- a/internal/provider/resource_locally_signed_cert_test.go
+++ b/internal/provider/resource_locally_signed_cert_test.go
@@ -308,7 +308,7 @@ func TestAccResourceLocallySignedCert_FromED25519PrivateKeyResource(t *testing.T
 						ca_private_key_pem = tls_private_key.ca_prv_test.private_key_pem
 					}
 				`,
-				Check: r.ComposeTestCheckFunc(
+				Check: r.ComposeAggregateTestCheckFunc(
 					r.TestCheckResourceAttr("tls_locally_signed_cert.test", "ca_key_algorithm", "ED25519"),
 					testCheckPEMFormat("tls_locally_signed_cert.test", "cert_pem", PreambleCertificate),
 				),
@@ -358,7 +358,7 @@ func TestAccResourceLocallySignedCert_FromECDSAPrivateKeyResource(t *testing.T) 
 						ca_private_key_pem = tls_private_key.ca_prv_test.private_key_pem
 					}
 				`,
-				Check: r.ComposeTestCheckFunc(
+				Check: r.ComposeAggregateTestCheckFunc(
 					r.TestCheckResourceAttr("tls_locally_signed_cert.test", "ca_key_algorithm", "ECDSA"),
 					testCheckPEMFormat("tls_locally_signed_cert.test", "cert_pem", PreambleCertificate),
 				),
@@ -408,7 +408,7 @@ func TestAccResourceLocallySignedCert_FromRSAPrivateKeyResource(t *testing.T) {
 						ca_private_key_pem = tls_private_key.ca_prv_test.private_key_pem
 					}
 				`,
-				Check: r.ComposeTestCheckFunc(
+				Check: r.ComposeAggregateTestCheckFunc(
 					r.TestCheckResourceAttr("tls_locally_signed_cert.test", "ca_key_algorithm", "RSA"),
 					testCheckPEMFormat("tls_locally_signed_cert.test", "cert_pem", PreambleCertificate),
 				),

--- a/internal/provider/resource_self_signed_cert.go
+++ b/internal/provider/resource_self_signed_cert.go
@@ -39,7 +39,7 @@ func createSelfSignedCert(_ context.Context, d *schema.ResourceData, _ interface
 	}
 
 	// Look for a 'subject' block
-	subject := getSubjectDistinguishedNames(d)
+	subject := createSubjectDistinguishedNames(d.Get("subject").([]interface{}))
 
 	// Add a `Subject` to the `Certificate` only if it was provided
 	cert := x509.Certificate{BasicConstraintsValid: true}

--- a/internal/provider/resource_self_signed_cert.go
+++ b/internal/provider/resource_self_signed_cert.go
@@ -39,10 +39,7 @@ func createSelfSignedCert(_ context.Context, d *schema.ResourceData, _ interface
 	}
 
 	// Look for a 'subject' block
-	subject, err := getSubjectDistinguishedNames(d)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	subject := getSubjectDistinguishedNames(d)
 
 	// Add a `Subject` to the `Certificate` only if it was provided
 	cert := x509.Certificate{BasicConstraintsValid: true}

--- a/internal/provider/resource_self_signed_cert.go
+++ b/internal/provider/resource_self_signed_cert.go
@@ -38,19 +38,16 @@ func createSelfSignedCert(_ context.Context, d *schema.ResourceData, _ interface
 		return diag.Errorf("error setting value on key 'key_algorithm': %s", err)
 	}
 
-	subjectConfs := d.Get("subject").([]interface{})
-	if len(subjectConfs) != 1 {
-		return diag.Errorf("must have exactly one 'subject' block")
+	// Look for a 'subject' block
+	subject, err := getSubjectDistinguishedNames(d)
+	if err != nil {
+		return diag.FromErr(err)
 	}
-	subjectConf, ok := subjectConfs[0].(map[string]interface{})
-	if !ok {
-		return diag.Errorf("subject block cannot be empty")
-	}
-	subject := distinguishedNamesFromSubjectAttributes(subjectConf)
 
-	cert := x509.Certificate{
-		Subject:               *subject,
-		BasicConstraintsValid: true,
+	// Add a `Subject` to the `Certificate` only if it was provided
+	cert := x509.Certificate{BasicConstraintsValid: true}
+	if subject != nil {
+		cert.Subject = *subject
 	}
 
 	dnsNamesI := d.Get("dns_names").([]interface{})

--- a/internal/provider/resource_self_signed_cert_test.go
+++ b/internal/provider/resource_self_signed_cert_test.go
@@ -324,7 +324,6 @@ func TestAccResourceSelfSignedCert_InvalidConfigs(t *testing.T) {
 					}
 					resource "tls_self_signed_cert" "test" {
 						private_key_pem = tls_private_key.test.private_key_pem
-						is_ca_certificate     = true
 						set_subject_key_id    = true
 						validity_period_hours = 8760
 						subject {}
@@ -338,6 +337,26 @@ func TestAccResourceSelfSignedCert_InvalidConfigs(t *testing.T) {
 					}
 				`,
 				ExpectError: regexp.MustCompile("Too many (list items|subject blocks)"),
+			},
+			{
+				Config: `
+					resource "tls_private_key" "test" {
+						algorithm = "ED25519"
+					}
+					resource "tls_self_signed_cert" "test" {
+						private_key_pem = tls_private_key.test.private_key_pem
+						is_ca_certificate     = true
+						set_subject_key_id    = true
+						validity_period_hours = 8760
+						allowed_uses = [
+							"key_encipherment",
+						]
+						ip_addresses = [
+							"127.0.0.2",
+						]
+					}
+				`,
+				ExpectError: regexp.MustCompile(`Certificate Subject must contain at least one Distinguished Name when creating Certificate Authority \(CA\)`),
 			},
 		},
 	})
@@ -543,7 +562,6 @@ func TestAccResourceSelfSignedCert_NoSubject(t *testing.T) {
 					}
 					resource "tls_self_signed_cert" "test" {
 						private_key_pem = tls_private_key.test.private_key_pem
-						is_ca_certificate     = true
 						set_subject_key_id    = true
 						validity_period_hours = 8760
 						subject {}
@@ -595,7 +613,6 @@ func TestAccResourceSelfSignedCert_NoSubject(t *testing.T) {
 					}
 					resource "tls_self_signed_cert" "test" {
 						private_key_pem = tls_private_key.test.private_key_pem
-						is_ca_certificate     = true
 						set_subject_key_id    = true
 						validity_period_hours = 8760
 						allowed_uses = [

--- a/internal/provider/resource_self_signed_cert_test.go
+++ b/internal/provider/resource_self_signed_cert_test.go
@@ -478,7 +478,7 @@ func TestAccResourceSelfSignedCert_FromED25519PrivateKeyResource(t *testing.T) {
 						]
 					}
 				`,
-				Check: r.ComposeTestCheckFunc(
+				Check: r.ComposeAggregateTestCheckFunc(
 					r.TestCheckResourceAttr("tls_self_signed_cert.test", "key_algorithm", "ED25519"),
 					testCheckPEMFormat("tls_self_signed_cert.test", "cert_pem", PreambleCertificate),
 				),
@@ -510,7 +510,7 @@ func TestAccResourceSelfSignedCert_FromECDSAPrivateKeyResource(t *testing.T) {
 						]
 					}
 				`,
-				Check: r.ComposeTestCheckFunc(
+				Check: r.ComposeAggregateTestCheckFunc(
 					r.TestCheckResourceAttr("tls_self_signed_cert.test", "key_algorithm", "ECDSA"),
 					testCheckPEMFormat("tls_self_signed_cert.test", "cert_pem", PreambleCertificate),
 				),
@@ -542,7 +542,7 @@ func TestAccResourceSelfSignedCert_FromRSAPrivateKeyResource(t *testing.T) {
 						]
 					}
 				`,
-				Check: r.ComposeTestCheckFunc(
+				Check: r.ComposeAggregateTestCheckFunc(
 					r.TestCheckResourceAttr("tls_self_signed_cert.test", "key_algorithm", "RSA"),
 					testCheckPEMFormat("tls_self_signed_cert.test", "cert_pem", PreambleCertificate),
 				),
@@ -583,9 +583,10 @@ func TestAccResourceSelfSignedCert_NoSubject(t *testing.T) {
 						]
 					}
 				`,
-				Check: r.ComposeTestCheckFunc(
+				Check: r.ComposeAggregateTestCheckFunc(
 					r.TestCheckResourceAttr("tls_self_signed_cert.test", "key_algorithm", "ED25519"),
 					testCheckPEMFormat("tls_self_signed_cert.test", "cert_pem", PreambleCertificate),
+					testCheckPEMCertificateNoSubject("tls_self_signed_cert.test", "cert_pem"),
 					testCheckPEMCertificateKeyUsage("tls_self_signed_cert.test", "cert_pem", x509.KeyUsageCertSign|x509.KeyUsageKeyEncipherment|x509.KeyUsageDigitalSignature),
 					testCheckPEMCertificateExtKeyUsages("tls_self_signed_cert.test", "cert_pem", []x509.ExtKeyUsage{
 						x509.ExtKeyUsageServerAuth,
@@ -633,9 +634,10 @@ func TestAccResourceSelfSignedCert_NoSubject(t *testing.T) {
 						]
 					}
 				`,
-				Check: r.ComposeTestCheckFunc(
+				Check: r.ComposeAggregateTestCheckFunc(
 					r.TestCheckResourceAttr("tls_self_signed_cert.test", "key_algorithm", "ED25519"),
 					testCheckPEMFormat("tls_self_signed_cert.test", "cert_pem", PreambleCertificate),
+					testCheckPEMCertificateNoSubject("tls_self_signed_cert.test", "cert_pem"),
 					testCheckPEMCertificateKeyUsage("tls_self_signed_cert.test", "cert_pem", x509.KeyUsageCertSign|x509.KeyUsageKeyEncipherment|x509.KeyUsageDigitalSignature),
 					testCheckPEMCertificateExtKeyUsages("tls_self_signed_cert.test", "cert_pem", []x509.ExtKeyUsage{
 						x509.ExtKeyUsageServerAuth,

--- a/internal/provider/resource_self_signed_cert_test.go
+++ b/internal/provider/resource_self_signed_cert_test.go
@@ -337,7 +337,7 @@ func TestAccResourceSelfSignedCert_InvalidConfigs(t *testing.T) {
 						]
 					}
 				`,
-				ExpectError: regexp.MustCompile("Too many subject blocks"),
+				ExpectError: regexp.MustCompile("Too many (list items|subject blocks)"),
 			},
 		},
 	})

--- a/internal/provider/resource_self_signed_cert_test.go
+++ b/internal/provider/resource_self_signed_cert_test.go
@@ -14,7 +14,7 @@ import (
 	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestSelfSignedCert(t *testing.T) {
+func TestAccResourceSelfSignedCert(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		ProviderFactories: testProviders,
 		Steps: []r.TestStep{
@@ -91,7 +91,7 @@ EOT
 }
 
 // TODO Remove this as part of https://github.com/hashicorp/terraform-provider-tls/issues/174
-func TestSelfSignedCert_HandleKeyAlgorithmDeprecation(t *testing.T) {
+func TestAccResourceSelfSignedCert_HandleKeyAlgorithmDeprecation(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		ProviderFactories: testProviders,
 		Steps: []r.TestStep{
@@ -142,7 +142,7 @@ func TestSelfSignedCert_HandleKeyAlgorithmDeprecation(t *testing.T) {
 	})
 }
 
-func TestAccSelfSignedCertRecreatesAfterExpired(t *testing.T) {
+func TestAccResourceSelfSignedCert_RecreatesAfterExpired(t *testing.T) {
 	oldNow := overridableTimeFunc
 	var previousCert string
 	r.UnitTest(t, r.TestCase{
@@ -196,7 +196,7 @@ func TestAccSelfSignedCertRecreatesAfterExpired(t *testing.T) {
 	overridableTimeFunc = oldNow
 }
 
-func TestAccSelfSignedCertNotRecreatedForEarlyRenewalUpdateInFuture(t *testing.T) {
+func TestAccResourceSelfSignedCert_NotRecreatedForEarlyRenewalUpdateInFuture(t *testing.T) {
 	oldNow := overridableTimeFunc
 	var previousCert string
 	r.UnitTest(t, r.TestCase{
@@ -250,7 +250,7 @@ func TestAccSelfSignedCertNotRecreatedForEarlyRenewalUpdateInFuture(t *testing.T
 	overridableTimeFunc = oldNow
 }
 
-func TestAccSelfSignedCertSetSubjectKeyID(t *testing.T) {
+func TestAccResourceSelfSignedCert_SetSubjectKeyID(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		ProviderFactories: testProviders,
 		PreCheck:          setTimeForTest("2019-06-14T12:00:00Z"),
@@ -282,7 +282,7 @@ EOT
 	})
 }
 
-func TestAccSelfSignedCert_InvalidConfigs(t *testing.T) {
+func TestAccResourceSelfSignedCert_InvalidConfigs(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		ProviderFactories: testProviders,
 		Steps: []r.TestStep{
@@ -316,6 +316,28 @@ func TestAccSelfSignedCert_InvalidConfigs(t *testing.T) {
 					}
 				`,
 				ExpectError: regexp.MustCompile(`expected early_renewal_hours to be at least \(0\), got -10`),
+			},
+			{
+				Config: `
+					resource "tls_private_key" "test" {
+						algorithm = "ED25519"
+					}
+					resource "tls_self_signed_cert" "test" {
+						private_key_pem = tls_private_key.test.private_key_pem
+						is_ca_certificate     = true
+						set_subject_key_id    = true
+						validity_period_hours = 8760
+						subject {}
+						subject {}
+						allowed_uses = [
+							"key_encipherment",
+						]
+						ip_addresses = [
+							"127.0.0.2",
+						]
+					}
+				`,
+				ExpectError: regexp.MustCompile("Too many subject blocks"),
 			},
 		},
 	})
@@ -477,6 +499,7 @@ func TestAccResourceSelfSignedCert_FromECDSAPrivateKeyResource(t *testing.T) {
 		},
 	})
 }
+
 func TestAccResourceSelfSignedCert_FromRSAPrivateKeyResource(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		ProviderFactories: testProviders,
@@ -503,6 +526,117 @@ func TestAccResourceSelfSignedCert_FromRSAPrivateKeyResource(t *testing.T) {
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("tls_self_signed_cert.test", "key_algorithm", "RSA"),
 					testCheckPEMFormat("tls_self_signed_cert.test", "cert_pem", PreambleCertificate),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceSelfSignedCert_NoSubject(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		ProviderFactories: testProviders,
+		Steps: []r.TestStep{
+			{
+				Config: `
+					resource "tls_private_key" "test" {
+						algorithm = "ED25519"
+					}
+					resource "tls_self_signed_cert" "test" {
+						private_key_pem = tls_private_key.test.private_key_pem
+						is_ca_certificate     = true
+						set_subject_key_id    = true
+						validity_period_hours = 8760
+						subject {}
+						allowed_uses = [
+							"key_encipherment",
+							"digital_signature",
+							"server_auth",
+							"client_auth",
+							"cert_signing",
+						]
+						dns_names = [
+							"pippo.pluto.paperino",
+						]
+						ip_addresses = [
+							"127.0.0.2",
+						]
+						uris = [
+							"disney://pippo.pluto.paperino/minnie",
+						]
+					}
+				`,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("tls_self_signed_cert.test", "key_algorithm", "ED25519"),
+					testCheckPEMFormat("tls_self_signed_cert.test", "cert_pem", PreambleCertificate),
+					testCheckPEMCertificateKeyUsage("tls_self_signed_cert.test", "cert_pem", x509.KeyUsageCertSign|x509.KeyUsageKeyEncipherment|x509.KeyUsageDigitalSignature),
+					testCheckPEMCertificateExtKeyUsages("tls_self_signed_cert.test", "cert_pem", []x509.ExtKeyUsage{
+						x509.ExtKeyUsageServerAuth,
+						x509.ExtKeyUsageClientAuth,
+					}),
+					testCheckPEMCertificateDNSNames("tls_self_signed_cert.test", "cert_pem", []string{
+						"pippo.pluto.paperino",
+					}),
+					testCheckPEMCertificateIPAddresses("tls_self_signed_cert.test", "cert_pem", []net.IP{
+						net.ParseIP("127.0.0.2"),
+					}),
+					testCheckPEMCertificateURIs("tls_self_signed_cert.test", "cert_pem", []*url.URL{
+						{
+							Scheme: "disney",
+							Host:   "pippo.pluto.paperino",
+							Path:   "minnie",
+						},
+					}),
+				),
+			},
+			{
+				Config: `
+					resource "tls_private_key" "test" {
+						algorithm = "ED25519"
+					}
+					resource "tls_self_signed_cert" "test" {
+						private_key_pem = tls_private_key.test.private_key_pem
+						is_ca_certificate     = true
+						set_subject_key_id    = true
+						validity_period_hours = 8760
+						allowed_uses = [
+							"key_encipherment",
+							"digital_signature",
+							"server_auth",
+							"client_auth",
+							"cert_signing",
+						]
+						dns_names = [
+							"pippo.pluto.paperino",
+						]
+						ip_addresses = [
+							"127.0.0.2",
+						]
+						uris = [
+							"disney://pippo.pluto.paperino/minnie",
+						]
+					}
+				`,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("tls_self_signed_cert.test", "key_algorithm", "ED25519"),
+					testCheckPEMFormat("tls_self_signed_cert.test", "cert_pem", PreambleCertificate),
+					testCheckPEMCertificateKeyUsage("tls_self_signed_cert.test", "cert_pem", x509.KeyUsageCertSign|x509.KeyUsageKeyEncipherment|x509.KeyUsageDigitalSignature),
+					testCheckPEMCertificateExtKeyUsages("tls_self_signed_cert.test", "cert_pem", []x509.ExtKeyUsage{
+						x509.ExtKeyUsageServerAuth,
+						x509.ExtKeyUsageClientAuth,
+					}),
+					testCheckPEMCertificateDNSNames("tls_self_signed_cert.test", "cert_pem", []string{
+						"pippo.pluto.paperino",
+					}),
+					testCheckPEMCertificateIPAddresses("tls_self_signed_cert.test", "cert_pem", []net.IP{
+						net.ParseIP("127.0.0.2"),
+					}),
+					testCheckPEMCertificateURIs("tls_self_signed_cert.test", "cert_pem", []*url.URL{
+						{
+							Scheme: "disney",
+							Host:   "pippo.pluto.paperino",
+							Path:   "minnie",
+						},
+					}),
 				),
 			},
 		},

--- a/internal/provider/test_check_func_test.go
+++ b/internal/provider/test_check_func_test.go
@@ -38,18 +38,21 @@ func testCheckPEMCertificateRequestSubject(name, key string, expected *pkix.Name
 	})
 }
 
+//nolint:unparam // `key` parameter always receives `cert_request_pem` because generated PEMs attributes are called that way.
 func testCheckPEMCertificateRequestDNSNames(name, key string, expected []string) r.TestCheckFunc {
 	return testCheckPEMCertificateRequestWith(name, key, func(csr *x509.CertificateRequest) error {
 		return compareCertDNSNames(expected, csr.DNSNames)
 	})
 }
 
+//nolint:unparam // `key` parameter always receives `cert_request_pem` because generated PEMs attributes are called that way.
 func testCheckPEMCertificateRequestIPAddresses(name, key string, expected []net.IP) r.TestCheckFunc {
 	return testCheckPEMCertificateRequestWith(name, key, func(csr *x509.CertificateRequest) error {
 		return compareCertIPAddresses(expected, csr.IPAddresses)
 	})
 }
 
+//nolint:unparam // `key` parameter always receives `cert_request_pem` because generated PEMs attributes are called that way.
 func testCheckPEMCertificateRequestURIs(name, key string, expected []*url.URL) r.TestCheckFunc {
 	return testCheckPEMCertificateRequestWith(name, key, func(csr *x509.CertificateRequest) error {
 		return compareCertURIs(expected, csr.URIs)


### PR DESCRIPTION
Closes #61 

RFC that motivates fixing this bug: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6

This affects 2 resources:

* `tls_cert_request`
* `tls_self_signed_cert`

### Caveat
In accordance with RFC 5280, the creation of the certificate will 
fail, if the desired certificate is a CA _and_ it has an empty Subject (i.e. no Distinguished Name is provided). Specifically, this part of the RFC:

> If the subject is a CA (e.g., the basic constraints extension, as discussed in [Section 4.2.1.9](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.9), is present and the value of cA is TRUE), then the subject field MUST be populated with a non-empty distinguished name matching the contents of the issuer field in all certificates issued by the subject CA.

### Small side improvement

Something that is possible to do with `tls_locally_signed_cert`, but it's probably undesirable, is to create a certificate using as CA a certificate that, in facts, is not one.

As this if functionally legit, now we will just raise a warning every time a certificate with this "quirk" gets created with this resource.

```
╷
│ Warning: CA is not a CA
│
│   with tls_locally_signed_cert.test,
│   on main.tf line 24, in resource "tls_locally_signed_cert" "test":
│   24: resource "tls_locally_signed_cert" "test" {
│
│ Certificate provided as Authority does not appear to be as much: the resulting certificate might fail
│ validations
╵
```