### PR TITLE
Add support for adding Authority Key ID to `tls_self_signed_cert`

### DIFF
--- a/docs/resources/self_signed_cert.md
+++ b/docs/resources/self_signed_cert.md
@@ -52,6 +52,7 @@ resource "tls_self_signed_cert" "example" {
 - `ip_addresses` (List of String) List of IP addresses for which a certificate is being requested (i.e. certificate subjects).
 - `is_ca_certificate` (Boolean) Is the generated certificate representing a Certificate Authority (CA) (default: `false`).
 - `key_algorithm` (String, Deprecated) Name of the algorithm used when generating the private key provided in `private_key_pem`. **NOTE**: this is deprecated and ignored, as the key algorithm is now inferred from the key.
+- `set_authority_key_id` (Boolean) Should the generated certificate include an [authority key identifier](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.1): for self-signed certificates this is the same value as the [subject key identifier](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2) (default: `false`).
 - `set_subject_key_id` (Boolean) Should the generated certificate include a [subject key identifier](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2) (default: `false`).
 - `subject` (Block List, Max: 1) The subject for which a certificate is being requested. The acceptable arguments are all optional and their naming is based upon [Issuer Distinguished Names (RFC5280)](https://tools.ietf.org/html/rfc5280#section-4.1.2.4) section. (see [below for nested schema](#nestedblock--subject))
 - `uris` (List of String) List of URIs for which a certificate is being requested (i.e. certificate subjects).

--- a/internal/provider/fixtures_test.go
+++ b/internal/provider/fixtures_test.go
@@ -174,6 +174,10 @@ DsM3TQL4LuEE9V2lU2L2f3kXKrkYzLJj7R4sGck5Fo/E8eeIFm1Z5FCPcia82N+C
 xDsNFvV3r8TsRH60IxFekKddI+ivepa97SvC4r+69MPyxULHNwDtSL+8T4q01LEP
 VKT7dWjBK3K0xxH0SPCtlqRbGalWz4adNNHazN/x7ebK+WB9ReSM
 -----END CERTIFICATE-----
-
 `
+)
+
+var (
+	testPrivateKeyPEMSubjectKeyID = []byte{207, 81, 38, 63, 172, 18, 241, 109, 195, 169, 6, 109, 237, 6, 18, 214, 52, 231, 17, 222}
+	testCAPrivateKeySubjectKeyID  = []byte{242, 39, 231, 129, 23, 93, 231, 171, 243, 171, 29, 48, 45, 93, 12, 82, 97, 100, 255, 81}
 )

--- a/internal/provider/resource_locally_signed_cert_test.go
+++ b/internal/provider/resource_locally_signed_cert_test.go
@@ -294,7 +294,7 @@ EOT
 				// Even if `set_subject_key_id` is set to `false`, the certificate will still get
 				// an Authority Key Identifier as it's provided by the CA
 				Check: r.ComposeAggregateTestCheckFunc(
-					testCheckPEMCertificateSubjectKeyID("tls_locally_signed_cert.test", "cert_pem", nil),
+					testCheckPEMCertificateNoSubjectKeyID("tls_locally_signed_cert.test", "cert_pem"),
 					testCheckPEMCertificateAuthorityKeyID("tls_locally_signed_cert.test", "cert_pem", testCAPrivateKeySubjectKeyID),
 				),
 			},
@@ -349,7 +349,7 @@ EOT
 				// NOTE: As the CA used for this certificate is a non-CA self-signed certificate that doesn't
 				// carry a Subject Key Identifier, this is reflected in the child certificate that has no
 				// Authority Key Identifier
-				Check: testCheckPEMCertificateAuthorityKeyID("tls_locally_signed_cert.test", "cert_pem", nil),
+				Check: testCheckPEMCertificateNoAuthorityKeyID("tls_locally_signed_cert.test", "cert_pem"),
 			},
 		},
 	})

--- a/internal/provider/resource_locally_signed_cert_test.go
+++ b/internal/provider/resource_locally_signed_cert_test.go
@@ -59,6 +59,7 @@ func TestAccResourceLocallySignedCert(t *testing.T) {
 					}),
 					testCheckPEMCertificateAgainstPEMRootCA("tls_locally_signed_cert.test", "cert_pem", []byte(testCACert)),
 					testCheckPEMCertificateDuration("tls_locally_signed_cert.test", "cert_pem", time.Hour),
+					testCheckPEMCertificateAuthorityKeyID("tls_locally_signed_cert.test", "cert_pem", testCAPrivateKeySubjectKeyID),
 				),
 			},
 		},
@@ -214,6 +215,7 @@ func TestAccResourceLocallySignedCert_HandleKeyAlgorithmDeprecation(t *testing.T
 					}),
 					testCheckPEMCertificateAgainstPEMRootCA("tls_locally_signed_cert.test", "cert_pem", []byte(testCACert)),
 					testCheckPEMCertificateDuration("tls_locally_signed_cert.test", "cert_pem", time.Hour),
+					testCheckPEMCertificateAuthorityKeyID("tls_locally_signed_cert.test", "cert_pem", testCAPrivateKeySubjectKeyID),
 				),
 			},
 		},
@@ -265,6 +267,92 @@ EOT
 %s
 EOT
         }`, testCertRequest, validity, earlyRenewal, testCACert, testCAPrivateKey)
+}
+
+func TestAccResourceLocallySignedCert_KeyIDs(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		ProviderFactories: testProviders,
+		Steps: []r.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "tls_locally_signed_cert" "test" {
+						cert_request_pem = <<EOT
+%s
+EOT
+						validity_period_hours = 1
+						early_renewal_hours = 0
+						allowed_uses = ["server_auth"]
+						set_subject_key_id = false
+						ca_cert_pem = <<EOT
+%s
+EOT
+						ca_private_key_pem = <<EOT
+%s
+EOT
+                    }`, testCertRequest, testCACert, testCAPrivateKey,
+				),
+				// Even if `set_subject_key_id` is set to `false`, the certificate will still get
+				// an Authority Key Identifier as it's provided by the CA
+				Check: r.ComposeAggregateTestCheckFunc(
+					testCheckPEMCertificateSubjectKeyID("tls_locally_signed_cert.test", "cert_pem", nil),
+					testCheckPEMCertificateAuthorityKeyID("tls_locally_signed_cert.test", "cert_pem", testCAPrivateKeySubjectKeyID),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "tls_locally_signed_cert" "test" {
+						cert_request_pem = <<EOT
+%s
+EOT
+						validity_period_hours = 1
+						early_renewal_hours = 0
+						allowed_uses = ["server_auth"]
+						set_subject_key_id = true
+						ca_cert_pem = <<EOT
+%s
+EOT
+						ca_private_key_pem = <<EOT
+%s
+EOT
+                    }`, testCertRequest, testCACert, testCAPrivateKey,
+				),
+				Check: r.ComposeAggregateTestCheckFunc(
+					testCheckPEMCertificateSubjectKeyID("tls_locally_signed_cert.test", "cert_pem", testPrivateKeyPEMSubjectKeyID),
+					testCheckPEMCertificateAuthorityKeyID("tls_locally_signed_cert.test", "cert_pem", testCAPrivateKeySubjectKeyID),
+				),
+			},
+			{
+				Config: `
+					resource "tls_private_key" "ca_prv_test" {
+						algorithm = "ED25519"
+					}
+					resource "tls_self_signed_cert" "ca_cert_test" {
+						private_key_pem = tls_private_key.ca_prv_test.private_key_pem
+						validity_period_hours = 8760
+						allowed_uses = ["cert_signing"]
+					}
+					resource "tls_private_key" "test" {
+						algorithm = "ED25519"
+					}
+					resource "tls_cert_request" "test" {
+						private_key_pem = tls_private_key.test.private_key_pem
+					}
+					resource "tls_locally_signed_cert" "test" {
+						validity_period_hours = 1
+						early_renewal_hours = 0
+						allowed_uses = ["server_auth", "client_auth"]
+						cert_request_pem = tls_cert_request.test.cert_request_pem
+						ca_cert_pem = tls_self_signed_cert.ca_cert_test.cert_pem
+						ca_private_key_pem = tls_private_key.ca_prv_test.private_key_pem
+					}
+				`,
+				// NOTE: As the CA used for this certificate is a non-CA self-signed certificate that doesn't
+				// carry a Subject Key Identifier, this is reflected in the child certificate that has no
+				// Authority Key Identifier
+				Check: testCheckPEMCertificateAuthorityKeyID("tls_locally_signed_cert.test", "cert_pem", nil),
+			},
+		},
+	})
 }
 
 func TestAccResourceLocallySignedCert_FromED25519PrivateKeyResource(t *testing.T) {
@@ -433,9 +521,7 @@ func TestAccResourceLocallySignedCert_InvalidConfigs(t *testing.T) {
 						}
 						is_ca_certificate     = true
 						validity_period_hours = 8760
-						allowed_uses = [
-							"cert_signing",
-						]
+						allowed_uses = ["cert_signing"]
 					}
 					resource "tls_private_key" "test" {
 						algorithm = "ED25519"
@@ -447,10 +533,7 @@ func TestAccResourceLocallySignedCert_InvalidConfigs(t *testing.T) {
 						is_ca_certificate = true
 						validity_period_hours = 1
 						early_renewal_hours = 0
-						allowed_uses = [
-							"server_auth",
-							"client_auth",
-						]
+						allowed_uses = ["server_auth", "client_auth"]
 						cert_request_pem = tls_cert_request.test.cert_request_pem
 						ca_cert_pem = tls_self_signed_cert.ca_cert_test.cert_pem
 						ca_private_key_pem = tls_private_key.ca_prv_test.private_key_pem

--- a/internal/provider/resource_self_signed_cert.go
+++ b/internal/provider/resource_self_signed_cert.go
@@ -16,6 +16,16 @@ func resourceSelfSignedCert() *schema.Resource {
 	setCertificateCommonSchema(s)
 	setCertificateSubjectSchema(s)
 
+	s["set_authority_key_id"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		ForceNew: true,
+		Description: "Should the generated certificate include an " +
+			"[authority key identifier](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.1): " +
+			"for self-signed certificates this is the same value as the " +
+			"[subject key identifier](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2) (default: `false`).",
+	}
+
 	return &schema.Resource{
 		CreateContext: createSelfSignedCert,
 		DeleteContext: deleteCertificate,

--- a/internal/provider/resource_self_signed_cert_test.go
+++ b/internal/provider/resource_self_signed_cert_test.go
@@ -270,7 +270,7 @@ EOT
 				`, testPrivateKeyPEM),
 				Check: r.ComposeAggregateTestCheckFunc(
 					testCheckPEMCertificateSubjectKeyID("tls_self_signed_cert.test", "cert_pem", testPrivateKeyPEMSubjectKeyID),
-					testCheckPEMCertificateAuthorityKeyID("tls_self_signed_cert.test", "cert_pem", nil),
+					testCheckPEMCertificateNoAuthorityKeyID("tls_self_signed_cert.test", "cert_pem"),
 				),
 			},
 			{

--- a/internal/provider/test_check_func_test.go
+++ b/internal/provider/test_check_func_test.go
@@ -163,6 +163,10 @@ func testCheckPEMCertificateSubjectKeyID(name, key string, expected []byte) r.Te
 	})
 }
 
+func testCheckPEMCertificateNoSubjectKeyID(name, key string) r.TestCheckFunc {
+	return testCheckPEMCertificateSubjectKeyID(name, key, nil)
+}
+
 //nolint:unparam // `key` parameter always receives `cert_pem` because generated PEMs attributes are called that way.
 func testCheckPEMCertificateAuthorityKeyID(name, key string, expected []byte) r.TestCheckFunc {
 	return testCheckPEMCertificateWith(name, key, func(crt *x509.Certificate) error {
@@ -171,6 +175,10 @@ func testCheckPEMCertificateAuthorityKeyID(name, key string, expected []byte) r.
 		}
 		return nil
 	})
+}
+
+func testCheckPEMCertificateNoAuthorityKeyID(name, key string) r.TestCheckFunc {
+	return testCheckPEMCertificateAuthorityKeyID(name, key, nil)
 }
 
 func testCheckPEMCertificateAgainstPEMRootCA(name, key string, rootCA []byte) r.TestCheckFunc {

--- a/internal/provider/test_check_func_test.go
+++ b/internal/provider/test_check_func_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"bytes"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -148,6 +149,26 @@ func testCheckPEMCertificateDuration(name, key string, expected time.Duration) r
 			return fmt.Errorf("incorrect certificate validity duration: expected %s, got %s", expected, actual)
 		}
 
+		return nil
+	})
+}
+
+//nolint:unparam // `key` parameter always receives `cert_pem` because generated PEMs attributes are called that way.
+func testCheckPEMCertificateSubjectKeyID(name, key string, expected []byte) r.TestCheckFunc {
+	return testCheckPEMCertificateWith(name, key, func(crt *x509.Certificate) error {
+		if !bytes.Equal(crt.SubjectKeyId, expected) {
+			return fmt.Errorf("incorrect Subject Key ID\n  expected: %v\n  got: %v", expected, crt.SubjectKeyId)
+		}
+		return nil
+	})
+}
+
+//nolint:unparam // `key` parameter always receives `cert_pem` because generated PEMs attributes are called that way.
+func testCheckPEMCertificateAuthorityKeyID(name, key string, expected []byte) r.TestCheckFunc {
+	return testCheckPEMCertificateWith(name, key, func(crt *x509.Certificate) error {
+		if !bytes.Equal(crt.AuthorityKeyId, expected) {
+			return fmt.Errorf("incorrect Authority Key ID\n\t\texpected: %v\n\t\tgot: %v", expected, crt.AuthorityKeyId)
+		}
 		return nil
 	})
 }


### PR DESCRIPTION
Closes #56 
Closes #66

Initially the intention of this effort was to add `set_authority_key_id` attribute to both `tls_locally_signed_cert` and `tls_self_signed_cert`.

But during development I realised that `tls_locally_signed_cert` was already generating a certificate with Authority Key ID correctly set, if the provided CA did have a Subject Key ID correctly set (https://github.com/hashicorp/terraform-provider-tls/pull/66#issuecomment-1126063571).

So, this PR:
1. adds the new functionality to `tls_self_signed_cert`
2. adds tests to both `tls_locally_signed_cert` and `tls_self_signed_cert` to test their behaviour in this regard

NOTE: this PR is based on #209, so it contains it's commits too. #209 has to land first, then I'll rebase this on top of `main` and only then merge.