### PR TITLE
Making Provider's `proxy.from_env` default to `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ BREAKING CHANGES:
 * resource/tls_locally_signed_cert: Attributes `cert_request_pem`, `ca_private_key_pem`, `ca_cert_pem` are stored (and returned) _as-is_ (in accordance with [guidelines](https://www.terraform.io/plugin/sdkv2/best-practices/sensitive-state#don-t-encrypt-state)) ([#87](https://github.com/hashicorp/terraform-provider-tls/issues/87), [#215](https://github.com/hashicorp/terraform-provider-tls/pull/215)).
 
 * provider: HTTP `proxy` configuration is now a (nested) Attribute (`proxy = {...`), not a Block (`proxy { ...`) ([#215](https://github.com/hashicorp/terraform-provider-tls/pull/215)).
+* provider: Default value for `proxy.from_env` is now `true`, and relies upon [`httpproxy.FromEnvironment`](https://pkg.go.dev/golang.org/x/net/http/httpproxy#FromEnvironment) ([#224](https://github.com/hashicorp/terraform-provider-tls/pull/224)).
 
 ## 3.4.0 (May 16, 2022)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,7 +116,7 @@ data "tls_certificate" "test" {
 
 Optional:
 
-- `from_env` (Boolean) When `true` the provider will discover the proxy configuration from environment variables. This is based upon [`http.ProxyFromEnvironment`](https://pkg.go.dev/net/http#ProxyFromEnvironment) and it supports the same environment variables (default: `false`). **NOTE**: the default value for this argument will be change to `true` in the next major release.
+- `from_env` (Boolean) When `true` the provider will discover the proxy configuration from environment variables. This is based upon [`http.ProxyFromEnvironment`](https://pkg.go.dev/net/http#ProxyFromEnvironment) and it supports the same environment variables (default: `true`).
 - `password` (String, Sensitive) Password used for Basic authentication against the Proxy.
 - `url` (String) URL used to connect to the Proxy. Accepted schemes are: `http`, `https`, `socks5`.
 - `username` (String) Username (or Token) used for Basic authentication against the Proxy.

--- a/internal/provider/data_source_certificate.go
+++ b/internal/provider/data_source_certificate.go
@@ -235,13 +235,7 @@ func (ds *certificateDataSource) Read(ctx context.Context, req tfsdk.ReadDataSou
 				targetURL.Host += ":443"
 			}
 
-			// TODO remove this branch and default to use `fetchPeerCertificatesViaHTTPS`
-			//   as part of https://github.com/hashicorp/terraform-provider-tls/issues/183
-			if ds.provider.isProxyConfigured() {
-				peerCerts, err = fetchPeerCertificatesViaHTTPS(targetURL, shouldVerifyChain, ds.provider)
-			} else {
-				peerCerts, err = fetchPeerCertificatesViaTLS(targetURL, shouldVerifyChain)
-			}
+			peerCerts, err = fetchPeerCertificatesViaHTTPS(targetURL, shouldVerifyChain, ds.provider)
 		case TLSScheme.String():
 			if targetURL.Port() == "" {
 				res.Diagnostics.AddError("URL malformed", fmt.Sprintf("Port missing from URL: %s", targetURL.String()))

--- a/internal/provider/data_source_certificate_test.go
+++ b/internal/provider/data_source_certificate_test.go
@@ -19,7 +19,7 @@ func TestDataSourceCertificate_CertificateContent(t *testing.T) {
 			{
 				Config: `
 					data "tls_certificate" "test" {
-					  content = file("fixtures/certificate.pem")
+						content = file("fixtures/certificate.pem")
 					}
 				`,
 				Check: r.ComposeAggregateTestCheckFunc(
@@ -50,7 +50,7 @@ func TestAccDataSourceCertificate_UpgradeFromVersion3_4_0(t *testing.T) {
 				ExternalProviders: providerVersion340(),
 				Config: `
 					data "tls_certificate" "test" {
-					  content = file("fixtures/certificate.pem")
+						content = file("fixtures/certificate.pem")
 					}
 				`,
 				Check: r.ComposeAggregateTestCheckFunc(
@@ -74,7 +74,7 @@ func TestAccDataSourceCertificate_UpgradeFromVersion3_4_0(t *testing.T) {
 				ProtoV6ProviderFactories: protoV6ProviderFactories(),
 				Config: `
 					data "tls_certificate" "test" {
-					  content = file("fixtures/certificate.pem")
+						content = file("fixtures/certificate.pem")
 					}
 				`,
 				PlanOnly: true,
@@ -83,7 +83,7 @@ func TestAccDataSourceCertificate_UpgradeFromVersion3_4_0(t *testing.T) {
 				ProtoV6ProviderFactories: protoV6ProviderFactories(),
 				Config: `
 					data "tls_certificate" "test" {
-					  content = file("fixtures/certificate.pem")
+						content = file("fixtures/certificate.pem")
 					}
 				`,
 				Check: r.ComposeAggregateTestCheckFunc(
@@ -118,7 +118,7 @@ func TestAccDataSourceCertificate_TerraformIO(t *testing.T) {
 			{
 				Config: `
 					data "tls_certificate" "test" {
-					  url = "https://www.terraform.io/"
+						url = "https://www.terraform.io/"
 					}
 				`,
 				Check: r.ComposeAggregateTestCheckFunc(
@@ -166,7 +166,7 @@ func TestAccDataSourceCertificate_BadSSL(t *testing.T) {
 			{
 				Config: `
 					data "tls_certificate" "test" {
-					  url = "https://untrusted-root.badssl.com/"
+						url = "https://untrusted-root.badssl.com/"
 					}
 				`,
 				ExpectError: regexp.MustCompile(`certificate signed by unknown authority`),
@@ -174,8 +174,8 @@ func TestAccDataSourceCertificate_BadSSL(t *testing.T) {
 			{
 				Config: `
 					data "tls_certificate" "test" {
-					  url = "https://untrusted-root.badssl.com/"
-					  verify_chain = false
+						url = "https://untrusted-root.badssl.com/"
+						verify_chain = false
 					}
 				`,
 				Check: r.ComposeAggregateTestCheckFunc(
@@ -210,7 +210,7 @@ func TestDataSourceCertificate_CertificateContentNegativeTests(t *testing.T) {
 			{
 				Config: `
 					data "tls_certificate" "test" {
-					  content = "not a pem"
+						content = "not a pem"
 					}
 				`,
 				ExpectError: regexp.MustCompile("Failed to decoded PEM"),
@@ -218,7 +218,7 @@ func TestDataSourceCertificate_CertificateContentNegativeTests(t *testing.T) {
 			{
 				Config: `
 					data "tls_certificate" "test" {
-					  content = file("fixtures/private.pem")
+						content = file("fixtures/private.pem")
 					}
 				`,
 				ExpectError: regexp.MustCompile("Unexpected PEM preamble"),
@@ -226,8 +226,8 @@ func TestDataSourceCertificate_CertificateContentNegativeTests(t *testing.T) {
 			{
 				Config: `
 					data "tls_certificate" "test" {
-					  content = file("fixtures/private.pem")
-					  url     = "https://www.hashicorp.com"
+						content = file("fixtures/private.pem")
+						url     = "https://www.hashicorp.com"
 					}
 				`,
 				ExpectError: regexp.MustCompile(`More than one attribute out of "content,url" has been set`),
@@ -258,8 +258,8 @@ func TestDataSourceCertificate_HTTPSScheme(t *testing.T) {
 
 				Config: fmt.Sprintf(`
 					data "tls_certificate" "test" {
-					  url = "https://%s"
-					  verify_chain = false
+						url = "https://%s"
+						verify_chain = false
 					}
 				`, server.Address()),
 				Check: localTestCertificateChainCheckFunc(),
@@ -284,8 +284,8 @@ func TestDataSourceCertificate_TLSScheme(t *testing.T) {
 
 				Config: fmt.Sprintf(`
 					data "tls_certificate" "test" {
-					  url = "tls://%s"
-					  verify_chain = false
+						url = "tls://%s"
+						verify_chain = false
 					}
 				`, server.Address()),
 				Check: localTestCertificateChainCheckFunc(),
@@ -322,8 +322,8 @@ func TestDataSourceCertificate_HTTPSSchemeViaProxy(t *testing.T) {
 						}
 					}
 					data "tls_certificate" "test" {
-					  url = "https://%s"
-					  verify_chain = false
+						url = "https://%s"
+						verify_chain = false
 					}
 				`, proxy.Address(), server.Address()),
 				Check: localTestCertificateChainCheckFunc(),
@@ -362,8 +362,8 @@ func TestDataSourceCertificate_HTTPSSchemeViaProxyWithUsernameAuth(t *testing.T)
 						}
 					}
 					data "tls_certificate" "test" {
-					  url = "https://%s"
-					  verify_chain = false
+						url = "https://%s"
+						verify_chain = false
 					}
 				`, proxy.Address(), proxyUsername, server.Address()),
 				Check: r.ComposeAggregateTestCheckFunc(
@@ -381,8 +381,8 @@ func TestDataSourceCertificate_HTTPSSchemeViaProxyWithUsernameAuth(t *testing.T)
 						}
 					}
 					data "tls_certificate" "test" {
-					  url = "https://%s"
-					  verify_chain = false
+						url = "https://%s"
+						verify_chain = false
 					}
 				`, proxy.Address(), server.Address()),
 				ExpectError: regexp.MustCompile("Proxy Authentication Required"),
@@ -423,8 +423,8 @@ func TestDataSourceCertificate_HTTPSSchemeViaProxyWithUsernameAndPasswordAuth(t 
 						}
 					}
 					data "tls_certificate" "test" {
-					  url = "https://%s"
-					  verify_chain = false
+						url = "https://%s"
+						verify_chain = false
 					}
 				`, proxy.Address(), proxyUsername, proxyPassword, server.Address()),
 				Check: r.ComposeAggregateTestCheckFunc(
@@ -443,8 +443,8 @@ func TestDataSourceCertificate_HTTPSSchemeViaProxyWithUsernameAndPasswordAuth(t 
 						}
 					}
 					data "tls_certificate" "test" {
-					  url = "https://%s"
-					  verify_chain = false
+						url = "https://%s"
+						verify_chain = false
 					}
 				`, proxy.Address(), proxyUsername, server.Address()),
 				ExpectError: regexp.MustCompile("Proxy Authentication Required"),
@@ -481,8 +481,8 @@ func TestDataSourceCertificate_HTTPSSchemeViaProxyFromEnv(t *testing.T) {
 						}
 					}
 					data "tls_certificate" "test" {
-					  url = "https://%s"
-					  verify_chain = false
+						url = "https://%s"
+						verify_chain = false
 					}
 				`, server.Address()),
 				Check: r.ComposeAggregateTestCheckFunc(
@@ -493,8 +493,8 @@ func TestDataSourceCertificate_HTTPSSchemeViaProxyFromEnv(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 					data "tls_certificate" "test" {
-					  url = "https://%s"
-					  verify_chain = false
+						url = "https://%s"
+						verify_chain = false
 					}
 				`, server.Address()),
 				Check: r.ComposeAggregateTestCheckFunc(
@@ -528,8 +528,8 @@ func TestDataSourceCertificate_HTTPSSchemeViaProxyButNoProxyAvailable(t *testing
 					}
 
 					data "tls_certificate" "test" {
-					  url = "https://%s"
-					  verify_chain = false
+						url = "https://%s"
+						verify_chain = false
 					}
 				`, server.Address()),
 				ExpectError: regexp.MustCompile(`failed to fetch certificates from URL 'https': Get "https://\[::\]:\d+":(.|\s)*proxyconnect tcp: dial tcp \[::1\]:65535`),

--- a/internal/provider/data_source_certificate_test.go
+++ b/internal/provider/data_source_certificate_test.go
@@ -169,7 +169,7 @@ func TestAccDataSourceCertificate_BadSSL(t *testing.T) {
 						url = "https://untrusted-root.badssl.com/"
 					}
 				`,
-				ExpectError: regexp.MustCompile(`certificate signed by unknown authority`),
+				ExpectError: regexp.MustCompile(`certificate signed by[\s]*unknown[\s]*authority`),
 			},
 			{
 				Config: `

--- a/internal/provider/testutils/local_server.go
+++ b/internal/provider/testutils/local_server.go
@@ -1,18 +1,23 @@
 package testutils
 
 import (
+	"fmt"
 	"log"
 	"net"
 	"net/http"
 
 	"github.com/elazarl/goproxy"
 	"github.com/elazarl/goproxy/ext/auth"
+	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 // LocalServerTest is a simple HTTP server used for testing.
 type LocalServerTest struct {
-	listener net.Listener
-	server   *http.Server
+	listener      net.Listener
+	server        *http.Server
+	connActivated int
+	connClosed    int
 }
 
 // NewHTTPServer creates an HTTP server that listens on a random port.
@@ -22,48 +27,53 @@ func NewHTTPServer() (*LocalServerTest, error) {
 		return nil, err
 	}
 
-	return &LocalServerTest{
+	// Create HTTP server, listening on a randomly-selected port
+	localServer := &LocalServerTest{
 		listener: listener,
 		server: &http.Server{
 			Addr: listener.Addr().String(),
 		},
-	}, nil
+	}
+
+	// Count connections activated and closed
+	localServer.server.ConnState = func(conn net.Conn, state http.ConnState) {
+		if state == http.StateActive {
+			localServer.connActivated++
+		}
+		if state == http.StateClosed {
+			localServer.connClosed++
+		}
+	}
+
+	return localServer, nil
 }
 
 // NewHTTPProxyServer creates an HTTP Proxy server that listens on a random port.
 func NewHTTPProxyServer() (*LocalServerTest, error) {
-	listener, err := net.Listen("tcp", ":0")
+	localServer, err := NewHTTPServer()
 	if err != nil {
 		return nil, err
 	}
 
-	return &LocalServerTest{
-		listener: listener,
-		server: &http.Server{
-			Addr:    listener.Addr().String(),
-			Handler: goproxy.NewProxyHttpServer(),
-		},
-	}, nil
+	// Turn http server into a proxy
+	localServer.server.Handler = goproxy.NewProxyHttpServer()
+
+	return localServer, nil
 }
 
 // NewHTTPProxyServerWithBasicAuth creates an HTTP Proxy server that listens on a random port and expects HTTP Basic Auth.
 func NewHTTPProxyServerWithBasicAuth(expectedUsername, expectedPassword string) (*LocalServerTest, error) {
-	listener, err := net.Listen("tcp", ":0")
+	proxy, err := NewHTTPProxyServer()
 	if err != nil {
 		return nil, err
 	}
 
-	proxy := goproxy.NewProxyHttpServer()
-	proxy.OnRequest().HandleConnect(auth.BasicConnect("restricted", func(username, password string) bool {
+	// Add "HTTP Connect auth handler" to proxy server
+	proxy.server.Handler.(*goproxy.ProxyHttpServer).OnRequest().HandleConnect(auth.BasicConnect("restricted", func(username, password string) bool {
 		return username == expectedUsername && (expectedPassword == "" || password == expectedPassword)
 	}))
-	return &LocalServerTest{
-		listener: listener,
-		server: &http.Server{
-			Addr:    listener.Addr().String(),
-			Handler: proxy,
-		},
-	}, nil
+
+	return proxy, nil
 }
 
 // ServeTLS makes the server begin listening for TLS client connections.
@@ -94,4 +104,24 @@ func (lst *LocalServerTest) Close() error {
 
 func (lst *LocalServerTest) Address() string {
 	return lst.listener.Addr().String()
+}
+
+func (lst *LocalServerTest) ConnActivated() int {
+	return lst.connActivated
+}
+
+func (lst *LocalServerTest) ConnClosed() int {
+	return lst.connClosed
+}
+
+func TestCheckBothServerAndProxyWereUsed(server, proxy *LocalServerTest) r.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		if server.ConnActivated() != proxy.ConnActivated() {
+			return fmt.Errorf("expected server and proxy actived connection count to match: server was %d, while proxy was %d", server.ConnActivated(), proxy.ConnActivated())
+		}
+		if server.ConnClosed() != proxy.ConnClosed() {
+			return fmt.Errorf("expected server and proxy closed connection count to match: server was %d, while proxy was %d", server.ConnClosed(), proxy.ConnClosed())
+		}
+		return nil
+	}
 }


### PR DESCRIPTION
Closes #183 