### PR TITLE
BUGFIX: use `ListType` of `ObjectType` for `Computed` attributes instead of `Blocks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* data-source/tls_certificate: Reworked internal schema allowing Terraform to detect that `certificates` is a _read-only_ (`Computed`) attribute, and as such it's unknown until the certificates are fetched ([#244](https://github.com/hashicorp/terraform-provider-tls/issues/244)). 
+* data-source/tls_certificate: Prevented `empty list of object` error with `certificates` attribute ([#244](https://github.com/hashicorp/terraform-provider-tls/issues/244)).
 
 ## 4.0.0 (July 21, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.1 (July 25, 2022)
+
+BUG FIXES:
+
+* data-source/tls_certificate: Reworked internal schema allowing Terraform to detect that `certificates` is a _read-only_ (`Computed`) attribute, and as such it's unknown until the certificates are fetched ([#244](https://github.com/hashicorp/terraform-provider-tls/issues/244)). 
+
 ## 4.0.0 (July 21, 2022)
 
 NOTES:

--- a/internal/provider/data_source_certificate.go
+++ b/internal/provider/data_source_certificate.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/schemavalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -90,7 +89,7 @@ func (dst *certificateDataSourceType) GetSchema(_ context.Context) (tfsdk.Schema
 						AttrTypes: x509CertObjectAttrTypes(),
 					},
 				},
-				Computed: true,
+				Computed:            true,
 				MarkdownDescription: "The certificates protecting the site, with the root of the chain first.",
 			},
 		},

--- a/internal/provider/data_source_certificate.go
+++ b/internal/provider/data_source_certificate.go
@@ -84,82 +84,15 @@ func (dst *certificateDataSourceType) GetSchema(_ context.Context) (tfsdk.Schema
 				Computed:            true,
 				MarkdownDescription: "Unique identifier of this data source: hashing of the certificates in the chain.",
 			},
-		},
-		Blocks: map[string]tfsdk.Block{
 			"certificates": {
-				NestingMode: tfsdk.BlockNestingModeList,
-				MinItems:    0,
-				// TODO Remove the validators below, once a fix for https://github.com/hashicorp/terraform-plugin-framework/issues/421 ships
-				Validators: []tfsdk.AttributeValidator{
-					listvalidator.SizeAtLeast(0),
+				Type: types.ListType{
+					ElemType: types.ObjectType{
+						AttrTypes: x509CertObjectAttrTypes(),
+					},
 				},
-				Attributes: map[string]tfsdk.Attribute{
-					"signature_algorithm": {
-						Type:                types.StringType,
-						Computed:            true,
-						MarkdownDescription: "The algorithm used to sign the certificate.",
-					},
-					"public_key_algorithm": {
-						Type:                types.StringType,
-						Computed:            true,
-						MarkdownDescription: "The key algorithm used to create the certificate.",
-					},
-					"serial_number": {
-						Type:     types.StringType,
-						Computed: true,
-						MarkdownDescription: "Number that uniquely identifies the certificate with the CA's system. " +
-							"The `format` function can be used to convert this _base 10_ number " +
-							"into other bases, such as hex.",
-					},
-					"is_ca": {
-						Type:                types.BoolType,
-						Computed:            true,
-						MarkdownDescription: "`true` if the certificate is of a CA (Certificate Authority).",
-					},
-					"version": {
-						Type:                types.Int64Type,
-						Computed:            true,
-						MarkdownDescription: "The version the certificate is in.",
-					},
-					"issuer": {
-						Type:     types.StringType,
-						Computed: true,
-						MarkdownDescription: "Who verified and signed the certificate, roughly following " +
-							"[RFC2253](https://tools.ietf.org/html/rfc2253).",
-					},
-					"subject": {
-						Type:     types.StringType,
-						Computed: true,
-						MarkdownDescription: "The entity the certificate belongs to, roughly following " +
-							"[RFC2253](https://tools.ietf.org/html/rfc2253).",
-					},
-					"not_before": {
-						Type:     types.StringType,
-						Computed: true,
-						MarkdownDescription: "The time after which the certificate is valid, as an " +
-							"[RFC3339](https://tools.ietf.org/html/rfc3339) timestamp.",
-					},
-					"not_after": {
-						Type:     types.StringType,
-						Computed: true,
-						MarkdownDescription: "The time until which the certificate is invalid, as an " +
-							"[RFC3339](https://tools.ietf.org/html/rfc3339) timestamp.",
-					},
-					"sha1_fingerprint": {
-						Type:                types.StringType,
-						Computed:            true,
-						MarkdownDescription: "The SHA1 fingerprint of the public key of the certificate.",
-					},
-					"cert_pem": {
-						Type:     types.StringType,
-						Computed: true,
-						MarkdownDescription: "Certificate data in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format. " +
-							"**NOTE**: the [underlying](https://pkg.go.dev/encoding/pem#Encode) " +
-							"[libraries](https://pkg.go.dev/golang.org/x/crypto/ssh#MarshalAuthorizedKey) that generate this " +
-							"value append a `\\n` at the end of the PEM. " +
-							"In case this disrupts your use case, we recommend using " +
-							"[`trimspace()`](https://www.terraform.io/language/functions/trimspace).",
-					},
+				Computed: true,
+				Validators: []tfsdk.AttributeValidator{
+					listvalidator.SizeAtLeast(1),
 				},
 				MarkdownDescription: "The certificates protecting the site, with the root of the chain first.",
 			},

--- a/internal/provider/data_source_certificate.go
+++ b/internal/provider/data_source_certificate.go
@@ -91,9 +91,6 @@ func (dst *certificateDataSourceType) GetSchema(_ context.Context) (tfsdk.Schema
 					},
 				},
 				Computed: true,
-				Validators: []tfsdk.AttributeValidator{
-					listvalidator.SizeAtLeast(1),
-				},
 				MarkdownDescription: "The certificates protecting the site, with the root of the chain first.",
 			},
 		},

--- a/internal/provider/data_source_certificate_test.go
+++ b/internal/provider/data_source_certificate_test.go
@@ -653,10 +653,15 @@ func TestDataSourceCertificate_UnknownComputedCertificatesUntilApplied(t *testin
 					}
 
 					data "tls_certificate" "test" {
+						# This attribute value must be unknown to trigger
+						# the behavior, therefore this replaces the unknown
+						# value with a known value on apply, so the URL is valid.
 						url = replace(tls_private_key.test.id, "/^.*$/","https://terraform.io")
 					}
 
 					output "test" {
+						# This test must reference an underlying value of the
+						# certificates attribute to trigger the behavior.
 						value = data.tls_certificate.test.certificates[0].sha1_fingerprint
 					}
 				`,


### PR DESCRIPTION
Closes #244

`Blocks`, on a protocol-level, don't support expressing the attribute of being `Computed`: `terraform-plugin-framework` doesn't support it ([yet?](https://github.com/hashicorp/terraform-plugin-framework/issues/214)).

But in our case it's possible to just do away with `Blocks` for the `tls_certificate.certificates`, and instead define an attribute of type `ListType`, that carries an `ObjectType`. By using an actual `Attribute`, we can then express the fact that this is a `Computed` attribute of the data source, and has such it's not expected to have a value until the `APPLY-PHASE` of Terraform. That will make the error encountered by practitioners in #224 go away.

NOTE: We CANNOT use `Attribute.NestAttributes` for this, as that would break the compatibility with Protocol 5, i.e with `TF >= 0.12`.