### PR TITLE
ci: merging `golangci-lint` rules + fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,25 @@
-linters:
-  # Default linters enabled
-  # See: https://golangci-lint.run/usage/linters/#enabled-by-default-linters
+issues:
+  max-per-linter: 0
+  max-same-issues: 0
 
-  # Additional linters enabled
+linters:
+  disable-all: true
   enable:
     - durationcheck
+    - errcheck
     - exportloopref
+    - forcetypeassert
     - godot
     - gofmt
+    - gosimple
+    - ineffassign
     - makezero
     - misspell
     - nilerr
     - predeclared
+    - staticcheck
     - tenv
     - unconvert
     - unparam
-
-run:
-  allow-parallel-runners: true
+    - unused
+    - vet

--- a/internal/provider/resource_cert_request.go
+++ b/internal/provider/resource_cert_request.go
@@ -254,8 +254,13 @@ func (r *certRequestResource) Create(ctx context.Context, req resource.CreateReq
 			"ipAddresses": newState.IPAddresses,
 		})
 
-		for _, ipElem := range newState.IPAddresses.Elements() {
-			ipStr := ipElem.(types.String).ValueString()
+		ipAddresses := make([]string, 0)
+		res.Diagnostics.Append(newState.IPAddresses.ElementsAs(ctx, &ipAddresses, false)...)
+		if res.Diagnostics.HasError() {
+			return
+		}
+
+		for _, ipStr := range ipAddresses {
 			ip := net.ParseIP(ipStr)
 			if ip == nil {
 				res.Diagnostics.AddError("Invalid IP address", fmt.Sprintf("Failed to parse %#v", ipStr))
@@ -271,8 +276,13 @@ func (r *certRequestResource) Create(ctx context.Context, req resource.CreateReq
 			"URIs": newState.URIs,
 		})
 
-		for _, uriElem := range newState.URIs.Elements() {
-			uriStr := uriElem.(types.String).ValueString()
+		uris := make([]string, 0)
+		res.Diagnostics.Append(newState.URIs.ElementsAs(ctx, &uris, false)...)
+		if res.Diagnostics.HasError() {
+			return
+		}
+
+		for _, uriStr := range uris {
 			uri, err := url.Parse(uriStr)
 			if err != nil {
 				res.Diagnostics.AddError("Invalid URI", fmt.Sprintf("Failed to parse %#v: %v", uriStr, err.Error()))

--- a/internal/provider/resource_cert_request.go
+++ b/internal/provider/resource_cert_request.go
@@ -254,7 +254,7 @@ func (r *certRequestResource) Create(ctx context.Context, req resource.CreateReq
 			"ipAddresses": newState.IPAddresses,
 		})
 
-		ipAddresses := make([]string, 0)
+		var ipAddresses []string
 		res.Diagnostics.Append(newState.IPAddresses.ElementsAs(ctx, &ipAddresses, false)...)
 		if res.Diagnostics.HasError() {
 			return
@@ -276,7 +276,7 @@ func (r *certRequestResource) Create(ctx context.Context, req resource.CreateReq
 			"URIs": newState.URIs,
 		})
 
-		uris := make([]string, 0)
+		var uris []string
 		res.Diagnostics.Append(newState.URIs.ElementsAs(ctx, &uris, false)...)
 		if res.Diagnostics.HasError() {
 			return

--- a/internal/provider/resource_cert_request.go
+++ b/internal/provider/resource_cert_request.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
@@ -64,6 +65,11 @@ func (r *certRequestResource) Schema(_ context.Context, req resource.SchemaReque
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.RequiresReplace(),
 				},
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(
+						stringvalidator.LengthAtLeast(1),
+					),
+				},
 				Description: "List of IP addresses for which a certificate is being requested (i.e. certificate subjects).",
 			},
 			"uris": schema.ListAttribute{
@@ -71,6 +77,11 @@ func (r *certRequestResource) Schema(_ context.Context, req resource.SchemaReque
 				Optional:    true,
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(
+						stringvalidator.LengthAtLeast(1),
+					),
 				},
 				Description: "List of URIs for which a certificate is being requested (i.e. certificate subjects).",
 			},

--- a/internal/provider/resource_self_signed_cert.go
+++ b/internal/provider/resource_self_signed_cert.go
@@ -101,6 +101,11 @@ func (r *selfSignedCertResource) Schema(_ context.Context, req resource.SchemaRe
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.RequiresReplace(),
 				},
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(
+						stringvalidator.LengthAtLeast(1),
+					),
+				},
 				Description: "List of IP addresses for which a certificate is being requested (i.e. certificate subjects).",
 			},
 			"uris": schema.ListAttribute{
@@ -108,6 +113,11 @@ func (r *selfSignedCertResource) Schema(_ context.Context, req resource.SchemaRe
 				Optional:    true,
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(
+						stringvalidator.LengthAtLeast(1),
+					),
 				},
 				Description: "List of URIs for which a certificate is being requested (i.e. certificate subjects).",
 			},

--- a/internal/provider/resource_self_signed_cert.go
+++ b/internal/provider/resource_self_signed_cert.go
@@ -359,8 +359,13 @@ func (r *selfSignedCertResource) Create(ctx context.Context, req resource.Create
 			"ipAddresses": newState.IPAddresses,
 		})
 
-		for _, ipElem := range newState.IPAddresses.Elements() {
-			ipStr := ipElem.(types.String).ValueString()
+		ipAddresses := make([]string, 0)
+		res.Diagnostics.Append(newState.IPAddresses.ElementsAs(ctx, &ipAddresses, false)...)
+		if res.Diagnostics.HasError() {
+			return
+		}
+
+		for _, ipStr := range ipAddresses {
 			ip := net.ParseIP(ipStr)
 			if ip == nil {
 				res.Diagnostics.AddError(
@@ -379,8 +384,13 @@ func (r *selfSignedCertResource) Create(ctx context.Context, req resource.Create
 			"URIs": newState.URIs,
 		})
 
-		for _, uriElem := range newState.URIs.Elements() {
-			uriStr := uriElem.(types.String).ValueString()
+		uris := make([]string, 0)
+		res.Diagnostics.Append(newState.URIs.ElementsAs(ctx, &uris, false)...)
+		if res.Diagnostics.HasError() {
+			return
+		}
+
+		for _, uriStr := range uris {
 			uri, err := url.Parse(uriStr)
 			if err != nil {
 				res.Diagnostics.AddError(

--- a/internal/provider/resource_self_signed_cert.go
+++ b/internal/provider/resource_self_signed_cert.go
@@ -359,7 +359,7 @@ func (r *selfSignedCertResource) Create(ctx context.Context, req resource.Create
 			"ipAddresses": newState.IPAddresses,
 		})
 
-		ipAddresses := make([]string, 0)
+		var ipAddresses []string
 		res.Diagnostics.Append(newState.IPAddresses.ElementsAs(ctx, &ipAddresses, false)...)
 		if res.Diagnostics.HasError() {
 			return
@@ -384,7 +384,7 @@ func (r *selfSignedCertResource) Create(ctx context.Context, req resource.Create
 			"URIs": newState.URIs,
 		})
 
-		uris := make([]string, 0)
+		var uris []string
 		res.Diagnostics.Append(newState.URIs.ElementsAs(ctx, &uris, false)...)
 		if res.Diagnostics.HasError() {
 			return

--- a/internal/provider/testutils/local_server.go
+++ b/internal/provider/testutils/local_server.go
@@ -68,8 +68,13 @@ func NewHTTPProxyServerWithBasicAuth(expectedUsername, expectedPassword string) 
 		return nil, err
 	}
 
+	proxyHttpServer, ok := proxy.server.Handler.(*goproxy.ProxyHttpServer)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type for %T proxy.Server.Handler", proxy.server.Handler)
+	}
+
 	// Add "HTTP Connect auth handler" to proxy server
-	proxy.server.Handler.(*goproxy.ProxyHttpServer).OnRequest().HandleConnect(auth.BasicConnect("restricted", func(username, password string) bool {
+	proxyHttpServer.OnRequest().HandleConnect(auth.BasicConnect("restricted", func(username, password string) bool {
 		return username == expectedUsername && (expectedPassword == "" || password == expectedPassword)
 	}))
 


### PR DESCRIPTION
contributes to:
- https://github.com/hashicorp/terraform-providers-devex-internal/issues/102

### Notes
- Fixed a couple type assertions by switching around the `Elements` looping. Not sure if this is the recommended approach? Can adjust if needed
- Skipping `paralleltest` for the providers
