### PR TITLE
Updated SHA1 fingerprint for live cert test

### DIFF
--- a/internal/provider/data_source_certificate_test.go
+++ b/internal/provider/data_source_certificate_test.go
@@ -198,7 +198,7 @@ func TestAccDataSourceCertificate_BadSSL(t *testing.T) {
 					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.signature_algorithm", "SHA256-RSA"),
 					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.public_key_algorithm", "RSA"),
 					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.is_ca", "false"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.sha1_fingerprint", "f74e83d61906664cd4922994ec11c2a18d05e6e1"),
+					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.sha1_fingerprint", "2506cdc034ca7ca72bedd6fcd95a3f059dfaf134"),
 				),
 			},
 		},


### PR DESCRIPTION
- Cert updated on https://untrusted-root.badssl.com/
- Fixes test failures: https://github.com/hashicorp/terraform-provider-tls/actions/runs/4632137870