### PR TITLE
docs: remove legacy behavior from `private_key_pem` attribute docs

### DIFF
--- a/docs/resources/cert_request.md
+++ b/docs/resources/cert_request.md
@@ -37,7 +37,7 @@ resource "tls_cert_request" "example" {
 
 ### Required
 
-- `private_key_pem` (String, Sensitive) Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, that the certificate will belong to. This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file) interpolation function. Only an irreversible secure hash of the private key will be stored in the Terraform state.
+- `private_key_pem` (String, Sensitive) Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, that the certificate will belong to. This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file) interpolation function.
 
 ### Optional
 

--- a/docs/resources/self_signed_cert.md
+++ b/docs/resources/self_signed_cert.md
@@ -42,7 +42,7 @@ resource "tls_self_signed_cert" "example" {
 ### Required
 
 - `allowed_uses` (List of String) List of key usages allowed for the issued certificate. Values are defined in [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280) and combine flags defined by both [Key Usages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3) and [Extended Key Usages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12). Accepted values: `any_extended`, `cert_signing`, `client_auth`, `code_signing`, `content_commitment`, `crl_signing`, `data_encipherment`, `decipher_only`, `digital_signature`, `email_protection`, `encipher_only`, `ipsec_end_system`, `ipsec_tunnel`, `ipsec_user`, `key_agreement`, `key_encipherment`, `microsoft_commercial_code_signing`, `microsoft_kernel_code_signing`, `microsoft_server_gated_crypto`, `netscape_server_gated_crypto`, `ocsp_signing`, `server_auth`, `timestamping`.
-- `private_key_pem` (String, Sensitive) Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, that the certificate will belong to. This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file) interpolation function. Only an irreversible secure hash of the private key will be stored in the Terraform state.
+- `private_key_pem` (String, Sensitive) Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, that the certificate will belong to. This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file) interpolation function.
 - `validity_period_hours` (Number) Number of hours, after initial issuing, that the certificate will remain valid for.
 
 ### Optional

--- a/internal/provider/resource_cert_request.go
+++ b/internal/provider/resource_cert_request.go
@@ -46,8 +46,7 @@ func (r *certRequestResource) Schema(_ context.Context, req resource.SchemaReque
 				Description: "Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, " +
 					"that the certificate will belong to. " +
 					"This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file) " +
-					"interpolation function. " +
-					"Only an irreversible secure hash of the private key will be stored in the Terraform state.",
+					"interpolation function.",
 			},
 
 			// Optional attributes

--- a/internal/provider/resource_self_signed_cert.go
+++ b/internal/provider/resource_self_signed_cert.go
@@ -55,8 +55,7 @@ func (r *selfSignedCertResource) Schema(_ context.Context, req resource.SchemaRe
 				Description: "Private key in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format, " +
 					"that the certificate will belong to. " +
 					"This can be read from a separate file using the [`file`](https://www.terraform.io/language/functions/file) " +
-					"interpolation function. " +
-					"Only an irreversible secure hash of the private key will be stored in the Terraform state.",
+					"interpolation function. ",
 			},
 			"validity_period_hours": schema.Int64Attribute{
 				Required: true,


### PR DESCRIPTION
Closes #365 

PR #215 updated the `private_key_pem` attribute to be stored as-is to reflect HashiCorp's guidance of [avoiding encrypting state](https://developer.hashicorp.com/terraform/plugin/best-practices/sensitive-state#don-t-encrypt-state), however the documentation was not updated to reflect this new behavior.