### PR TITLE
#35 - Implement email Address field into Cert Request resource

### DIFF
--- a/docs/cdktf/python/resources/cert_request.md
+++ b/docs/cdktf/python/resources/cert_request.md
@@ -78,5 +78,6 @@ Optional:
 - `province` (String) Distinguished name: `ST`
 - `serial_number` (String) Distinguished name: `SERIALNUMBER`
 - `street_address` (List of String) Distinguished name: `STREET`
+- `email_address` (String) Email address: `emailAddress (x509 1.2.840.113549.1.9.1)`
 
 <!-- cache-key: cdktf-0.18.0 input-f0b329ca4c0554d420316e3aa077babdcc26589666ed69b639e7ed93d15ac558 556251879b8ed0dc4c87a76b568667e0ab5e2c46efdd14a05c556daf05678783-->

--- a/docs/cdktf/typescript/resources/cert_request.md
+++ b/docs/cdktf/typescript/resources/cert_request.md
@@ -81,5 +81,6 @@ Optional:
 - `province` (String) Distinguished name: `st`
 - `serialNumber` (String) Distinguished name: `serialnumber`
 - `streetAddress` (List of String) Distinguished name: `street`
+- `email_address` (String) Email address: `emailAddress (x509 1.2.840.113549.1.9.1)`
 
 <!-- cache-key: cdktf-0.18.0 input-f0b329ca4c0554d420316e3aa077babdcc26589666ed69b639e7ed93d15ac558 556251879b8ed0dc4c87a76b568667e0ab5e2c46efdd14a05c556daf05678783-->

--- a/docs/resources/cert_request.md
+++ b/docs/resources/cert_request.md
@@ -66,3 +66,4 @@ Optional:
 - `province` (String) Distinguished name: `ST`
 - `serial_number` (String) Distinguished name: `SERIALNUMBER`
 - `street_address` (List of String) Distinguished name: `STREET`
+- `email_address` (String) Email address: `emailAddress (x509 1.2.840.113549.1.9.1)`

--- a/internal/provider/common_cert.go
+++ b/internal/provider/common_cert.go
@@ -385,5 +385,12 @@ func createSubjectDistinguishedNames(ctx context.Context, subject certificateSub
 		result.SerialNumber = subject.SerialNumber.ValueString()
 	}
 
+	if !subject.EmailAddress.IsNull() && !subject.EmailAddress.IsUnknown() {
+		result.ExtraNames = append(result.ExtraNames, pkix.AttributeTypeAndValue{
+			Type:  []int{1, 2, 840, 113549, 1, 9, 1},
+			Value: subject.EmailAddress.ValueString(),
+		})
+	}
+
 	return result
 }

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -60,6 +60,7 @@ type certificateSubjectModel struct {
 	Province           types.String `tfsdk:"province"`
 	Country            types.String `tfsdk:"country"`
 	PostalCode         types.String `tfsdk:"postal_code"`
+	EmailAddress       types.String `tfsdk:"email_address"`
 	SerialNumber       types.String `tfsdk:"serial_number"`
 }
 

--- a/internal/provider/resource_cert_request.go
+++ b/internal/provider/resource_cert_request.go
@@ -163,7 +163,7 @@ func (r *certRequestResource) Schema(_ context.Context, req resource.SchemaReque
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
 							},
-							Description: "Email Address: `email_address`",
+							Description: "Email Address: `1.2.840.113549.1.9.1`",
 						},
 						"locality": schema.StringAttribute{
 							Optional: true,

--- a/internal/provider/resource_cert_request.go
+++ b/internal/provider/resource_cert_request.go
@@ -158,6 +158,13 @@ func (r *certRequestResource) Schema(_ context.Context, req resource.SchemaReque
 							},
 							Description: "Distinguished name: `STREET`",
 						},
+						"email_address": schema.StringAttribute{
+							Optional: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+							Description: "Email Address: `email_address`",
+						},
 						"locality": schema.StringAttribute{
 							Optional: true,
 							PlanModifiers: []planmodifier.String{


### PR DESCRIPTION
Hello,

I've added email address into cert request generation (as I had the need and someone had requested this in the issue #35.

```hcl
resource "tls_cert_request" "example" {
  private_key_pem = file("private_key.pem")

  subject {
    common_name  = "example.com"
    organization       = "ACME Examples, Inc"
    email_address     = "test@example.com"
  }
}
```

I've tested on my side and worked correctly. I've updated the documentation with related elements.

Have a good day!