### PR TITLE
Adding ext key usages support for csr

### DIFF
--- a/docs/resources/cert_request.md
+++ b/docs/resources/cert_request.md
@@ -45,7 +45,8 @@ resource "tls_cert_request" "example" {
 - `ip_addresses` (List of String) List of IP addresses for which a certificate is being requested (i.e. certificate subjects).
 - `subject` (Block List) The subject for which a certificate is being requested. The acceptable arguments are all optional and their naming is based upon [Issuer Distinguished Names (RFC5280)](https://tools.ietf.org/html/rfc5280#section-4.1.2.4) section. (see [below for nested schema](#nestedblock--subject))
 - `uris` (List of String) List of URIs for which a certificate is being requested (i.e. certificate subjects).
-
+- `allowed_uses` (List of String) List of key usages for the certificate singing request. Accepted values: `any_extended`, `client_auth`, `code_signing`, `email_protection`, `ipsec_end_system`, `ipsec_tunnel`, `ipsec_user`, `microsoft_commercial_code_signing`, `microsoft_kernel_code_signing`, `microsoft_server_gated_crypto`, `netscape_server_gated_crypto`, `ocsp_signing`, `server_auth`, `timestamping`.
+-
 ### Read-Only
 
 - `cert_request_pem` (String) The certificate request data in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format. **NOTE**: the [underlying](https://pkg.go.dev/encoding/pem#Encode) [libraries](https://pkg.go.dev/golang.org/x/crypto/ssh#MarshalAuthorizedKey) that generate this value append a `\n` at the end of the PEM. In case this disrupts your use case, we recommend using [`trimspace()`](https://www.terraform.io/language/functions/trimspace).

--- a/internal/provider/common_cert.go
+++ b/internal/provider/common_cert.go
@@ -59,6 +59,23 @@ var extendedKeyUsages = map[string]x509.ExtKeyUsage{
 	"microsoft_kernel_code_signing":     x509.ExtKeyUsageMicrosoftKernelCodeSigning,
 }
 
+var extendedKeyUsageOIDs = map[string]asn1.ObjectIdentifier{
+	"any_extended":                      asn1.ObjectIdentifier{2, 5, 29, 37, 0},
+	"server_auth":                       asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 1},
+	"client_auth":                       asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 2},
+	"code_signing":                      asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 3},
+	"email_protection":                  asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 4},
+	"ipsec_end_system":                  asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 5},
+	"ipsec_tunnel":                      asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 6},
+	"ipsec_user":                        asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 7},
+	"timestamping":                      asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 8},
+	"ocsp_signing":                      asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 9},
+	"microsoft_server_gated_crypto":     asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 311, 10, 3, 3},
+	"netscape_server_gated_crypto":      asn1.ObjectIdentifier{2, 16, 840, 1, 113730, 4, 1},
+	"microsoft_commercial_code_signing": asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 311, 2, 1, 22},
+	"microsoft_kernel_code_signing":     asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 311, 61, 1, 1},
+}
+
 // supportedKeyUsagesStr returns a slice with all the keys in keyUsages and extendedKeyUsages.
 func supportedKeyUsagesStr() []string {
 	res := make([]string, 0, len(keyUsages)+len(extendedKeyUsages))
@@ -66,6 +83,18 @@ func supportedKeyUsagesStr() []string {
 	for k := range keyUsages {
 		res = append(res, k)
 	}
+	for k := range extendedKeyUsages {
+		res = append(res, k)
+	}
+	sort.Strings(res)
+
+	return res
+}
+
+// supportedEtendedKeyUsagesStr returns a slice with all the keys in extraExtensions.
+func supportedEtendedKeyUsagesStr() []string {
+	res := make([]string, 0, len(extendedKeyUsages))
+
 	for k := range extendedKeyUsages {
 		res = append(res, k)
 	}

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -44,6 +44,7 @@ type certRequestResourceModel struct {
 	DNSNames       types.List   `tfsdk:"dns_names"`
 	IPAddresses    types.List   `tfsdk:"ip_addresses"`
 	URIs           types.List   `tfsdk:"uris"`
+	AllowedUses    types.List   `tfsdk:"allowed_uses"`
 	PrivateKeyPEM  types.String `tfsdk:"private_key_pem"`
 	KeyAlgorithm   types.String `tfsdk:"key_algorithm"`
 	CertRequestPEM types.String `tfsdk:"cert_request_pem"`


### PR DESCRIPTION
Hello. We use this provider `tls_cert_request` resource to create csr, which will be used to issue certificates over certificate authority. We need to have possibility to specify some ext key usages for certificate, which we want to get. This changes intended to solve our needs. It should (maybe partially) support functionality, which was requested in https://github.com/hashicorp/terraform-provider-tls/issues/360