### PR TITLE
resource/tls_private_key: Fix testing for Terraform 1.8 non-refresh handling

### DIFF
--- a/internal/provider/resource_private_key_test.go
+++ b/internal/provider/resource_private_key_test.go
@@ -363,15 +363,11 @@ func TestAccPrivateKeyED25519_UpgradeFromVersion3_4_0(t *testing.T) {
 						algorithm = "ED25519"
 					}
 				`,
-				PlanOnly: true,
-			},
-			{
-				ProtoV5ProviderFactories: protoV5ProviderFactories(),
-				Config: `
-					resource "tls_private_key" "test" {
-						algorithm = "ED25519"
-					}
-				`,
+				ConfigPlanChecks: r.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 				Check: r.ComposeAggregateTestCheckFunc(
 					tu.TestCheckPEMFormat("tls_private_key.test", "private_key_pem", PreamblePrivateKeyPKCS8.String()),
 					tu.TestCheckPEMFormat("tls_private_key.test", "public_key_pem", PreamblePublicKey.String()),

--- a/internal/provider/resource_private_key_test.go
+++ b/internal/provider/resource_private_key_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 
 	tu "github.com/hashicorp/terraform-provider-tls/internal/provider/testutils"
 )
@@ -93,15 +94,11 @@ func TestAccPrivateKeyRSA_UpgradeFromVersion3_4_0(t *testing.T) {
 						algorithm = "RSA"
 					}
 				`,
-				PlanOnly: true,
-			},
-			{
-				ProtoV5ProviderFactories: protoV5ProviderFactories(),
-				Config: `
-					resource "tls_private_key" "test" {
-						algorithm = "RSA"
-					}
-				`,
+				ConfigPlanChecks: r.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 				Check: r.ComposeAggregateTestCheckFunc(
 					tu.TestCheckPEMFormat("tls_private_key.test", "private_key_pem", PreamblePrivateKeyRSA.String()),
 					r.TestCheckResourceAttrWith("tls_private_key.test", "private_key_pem", func(pem string) error {
@@ -155,15 +152,11 @@ func TestAccPrivateKeyRSA_UpgradeFromVersion3_1_0(t *testing.T) {
 						algorithm = "RSA"
 					}
 				`,
-				PlanOnly: true,
-			},
-			{
-				ProtoV5ProviderFactories: protoV5ProviderFactories(),
-				Config: `
-					resource "tls_private_key" "test" {
-						algorithm = "RSA"
-					}
-				`,
+				ConfigPlanChecks: r.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 				Check: r.ComposeAggregateTestCheckFunc(
 					tu.TestCheckPEMFormat("tls_private_key.test", "private_key_pem", PreamblePrivateKeyRSA.String()),
 					r.TestCheckResourceAttrWith("tls_private_key.test", "private_key_pem", func(pem string) error {
@@ -252,15 +245,11 @@ func TestAccPrivateKeyECDSA_UpgradeFromVersion3_4_0(t *testing.T) {
 						algorithm = "ECDSA"
 					}
 				`,
-				PlanOnly: true,
-			},
-			{
-				ProtoV5ProviderFactories: protoV5ProviderFactories(),
-				Config: `
-					resource "tls_private_key" "test" {
-						algorithm = "ECDSA"
-					}
-				`,
+				ConfigPlanChecks: r.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 				Check: r.ComposeAggregateTestCheckFunc(
 					tu.TestCheckPEMFormat("tls_private_key.test", "private_key_pem", PreamblePrivateKeyEC.String()),
 					tu.TestCheckPEMFormat("tls_private_key.test", "public_key_pem", PreamblePublicKey.String()),
@@ -304,16 +293,11 @@ func TestAccPrivateKeyECDSA_UpgradeFromVersion3_1_0(t *testing.T) {
 						ecdsa_curve = "P256"
 					}
 				`,
-				PlanOnly: true,
-			},
-			{
-				ProtoV5ProviderFactories: protoV5ProviderFactories(),
-				Config: `
-					resource "tls_private_key" "test" {
-						algorithm = "ECDSA"
-						ecdsa_curve = "P256"
-					}
-				`,
+				ConfigPlanChecks: r.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 				Check: r.ComposeAggregateTestCheckFunc(
 					tu.TestCheckPEMFormat("tls_private_key.test", "private_key_pem", PreamblePrivateKeyEC.String()),
 					tu.TestCheckPEMFormat("tls_private_key.test", "public_key_pem", PreamblePublicKey.String()),


### PR DESCRIPTION
Reference: https://developer.hashicorp.com/terraform/language/v1.8.x/upgrade-guides#possible-spurious-changes-when-refreshing

Previously some of the acceptance testing used `PlanOnly: true` which ran a non-refresh plan as its first step. After Terraform 1.8, additional attribute sensitivity metadata is saved into the state, which can cause a non-refresh plan difference and break these acceptance tests:

```
=== RUN   TestAccPrivateKeyRSA_UpgradeFromVersion3_4_0
    resource_private_key_test.go:64: Step 2/3 error: The non-refresh plan was not empty.
        stdout:

        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # tls_private_key.test will be updated in-place
          ~ resource "tls_private_key" "test" {
                id                            = "b8b2e2efc01d09ddb84c6e3f2c3505a0af85f618"
                # (10 unchanged attributes hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
    panic.go:523: Error retrieving state, there may be dangling resources: exit status 1
        Failed to marshal state to json: schema version 0 for tls_private_key.test in state does not match version 1 from the provider
--- FAIL: TestAccPrivateKeyRSA_UpgradeFromVersion3_4_0 (3.00s)

=== RUN   TestAccPrivateKeyRSA_UpgradeFromVersion3_1_0
    resource_private_key_test.go:126: Step 2/3 error: The non-refresh plan was not empty.
        stdout:

        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # tls_private_key.test will be updated in-place
          ~ resource "tls_private_key" "test" {
                id                            = "2af67f1dc66c843a5a0229d30b13af65471db156"
                # (10 unchanged attributes hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
    panic.go:523: Error retrieving state, there may be dangling resources: exit status 1
        Failed to marshal state to json: schema version 0 for tls_private_key.test in state does not match version 1 from the provider
--- FAIL: TestAccPrivateKeyRSA_UpgradeFromVersion3_1_0 (2.96s)

=== RUN   TestAccPrivateKeyECDSA_UpgradeFromVersion3_4_0
    resource_private_key_test.go:229: Step 2/3 error: The non-refresh plan was not empty.
        stdout:

        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # tls_private_key.test will be updated in-place
          ~ resource "tls_private_key" "test" {
                id                            = "c3493d603136c365e4b8274daa1c81c708cfd211"
                # (10 unchanged attributes hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
    panic.go:523: Error retrieving state, there may be dangling resources: exit status 1
        Failed to marshal state to json: schema version 0 for tls_private_key.test in state does not match version 1 from the provider
--- FAIL: TestAccPrivateKeyECDSA_UpgradeFromVersion3_4_0 (2.79s)

=== RUN   TestAccPrivateKeyECDSA_UpgradeFromVersion3_1_0
    resource_private_key_test.go:279: Step 2/3 error: The non-refresh plan was not empty.
        stdout:

        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # tls_private_key.test will be updated in-place
          ~ resource "tls_private_key" "test" {
                id                            = "f8918632397f6f430c018f083e9202b35c4b259e"
                # (10 unchanged attributes hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
    panic.go:523: Error retrieving state, there may be dangling resources: exit status 1
        Failed to marshal state to json: schema version 0 for tls_private_key.test in state does not match version 1 from the provider
--- FAIL: TestAccPrivateKeyECDSA_UpgradeFromVersion3_1_0 (2.70s)

=== RUN   TestAccPrivateKeyED25519_UpgradeFromVersion3_4_0
    resource_private_key_test.go:356: Step 2/3 error: The non-refresh plan was not empty.
        stdout:

        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # tls_private_key.test will be updated in-place
          ~ resource "tls_private_key" "test" {
                id                            = "369c5e30e9715cc63780bba11d6172b62dbea23d"
                # (10 unchanged attributes hidden)
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
    panic.go:523: Error retrieving state, there may be dangling resources: exit status 1
        Failed to marshal state to json: schema version 0 for tls_private_key.test in state does not match version 1 from the provider
--- FAIL: TestAccPrivateKeyED25519_UpgradeFromVersion3_4_0 (2.76s)
```

Adjusting this acceptance tests to replace `PlanOnly: true` with `plancheck.ExpectNoChanges()` covers the same desired behavior along with the more-common practitioner behavior of refresh plans rather than non-refresh plans after provider upgrades.