### PR TITLE
Adding support for specifying hashing algorithm

### DIFF
--- a/docs/resources/cert_request.md
+++ b/docs/resources/cert_request.md
@@ -42,6 +42,7 @@ resource "tls_cert_request" "example" {
 ### Optional
 
 - `dns_names` (List of String) List of DNS names for which a certificate is being requested (i.e. certificate subjects).
+- `hashing_algorithm` (String) The algorithm to use when hashing the certificate for signature signing Accepted values: `md2`, `md5`, `sha1`, `sha256`, `sha384`, `sha512`.
 - `ip_addresses` (List of String) List of IP addresses for which a certificate is being requested (i.e. certificate subjects).
 - `subject` (Block List) The subject for which a certificate is being requested. The acceptable arguments are all optional and their naming is based upon [Issuer Distinguished Names (RFC5280)](https://tools.ietf.org/html/rfc5280#section-4.1.2.4) section. (see [below for nested schema](#nestedblock--subject))
 - `uris` (List of String) List of URIs for which a certificate is being requested (i.e. certificate subjects).

--- a/docs/resources/locally_signed_cert.md
+++ b/docs/resources/locally_signed_cert.md
@@ -45,6 +45,7 @@ resource "tls_locally_signed_cert" "example" {
 ### Optional
 
 - `early_renewal_hours` (Number) The resource will consider the certificate to have expired the given number of hours before its actual expiry time. This can be useful to deploy an updated certificate in advance of the expiration of the current certificate. However, the old certificate remains valid until its true expiration time, since this resource does not (and cannot) support certificate revocation. Also, this advance update can only be performed should the Terraform configuration be applied during the early renewal period. (default: `0`)
+- `hashing_algorithm` (String) The algorithm to use when hashing the certificate for signature signing Accepted values: `md2`, `md5`, `sha1`, `sha256`, `sha384`, `sha512`.
 - `is_ca_certificate` (Boolean) Is the generated certificate representing a Certificate Authority (CA) (default: `false`).
 - `set_subject_key_id` (Boolean) Should the generated certificate include a [subject key identifier](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2) (default: `false`).
 

--- a/docs/resources/self_signed_cert.md
+++ b/docs/resources/self_signed_cert.md
@@ -49,6 +49,7 @@ resource "tls_self_signed_cert" "example" {
 
 - `dns_names` (List of String) List of DNS names for which a certificate is being requested (i.e. certificate subjects).
 - `early_renewal_hours` (Number) The resource will consider the certificate to have expired the given number of hours before its actual expiry time. This can be useful to deploy an updated certificate in advance of the expiration of the current certificate. However, the old certificate remains valid until its true expiration time, since this resource does not (and cannot) support certificate revocation. Also, this advance update can only be performed should the Terraform configuration be applied during the early renewal period. (default: `0`)
+- `hashing_algorithm` (String) The algorithm to use when hashing the certificate for signature signing Accepted values: `md2`, `md5`, `sha1`, `sha256`, `sha384`, `sha512`.
 - `ip_addresses` (List of String) List of IP addresses for which a certificate is being requested (i.e. certificate subjects).
 - `is_ca_certificate` (Boolean) Is the generated certificate representing a Certificate Authority (CA) (default: `false`).
 - `set_authority_key_id` (Boolean) Should the generated certificate include an [authority key identifier](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.1): for self-signed certificates this is the same value as the [subject key identifier](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2) (default: `false`).

--- a/internal/provider/common_cert.go
+++ b/internal/provider/common_cert.go
@@ -155,7 +155,7 @@ func generateSubjectKeyID(pubKey crypto.PublicKey) ([]byte, error) {
 // getSignatureAlgorithm calculates the algorithm based on the public key and the desired hash.
 func getSignatureAlgorithm(pubKey crypto.PublicKey, hashAlg string) (*x509.SignatureAlgorithm, error) {
 	var err error
-	var algorithm = hashAlg
+	var algorithm = strings.ToLower(hashAlg)
 
 	// lookup algorithm from public key type
 	switch pub := pubKey.(type) {

--- a/internal/provider/common_cert.go
+++ b/internal/provider/common_cert.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -57,6 +58,46 @@ var extendedKeyUsages = map[string]x509.ExtKeyUsage{
 	"netscape_server_gated_crypto":      x509.ExtKeyUsageNetscapeServerGatedCrypto,
 	"microsoft_commercial_code_signing": x509.ExtKeyUsageMicrosoftCommercialCodeSigning,
 	"microsoft_kernel_code_signing":     x509.ExtKeyUsageMicrosoftKernelCodeSigning,
+}
+
+var signatureAlgorithms = map[string]x509.SignatureAlgorithm{
+	"md2_rsa":       x509.MD2WithRSA,  // Unsupported
+	"md5_rsa":       x509.MD5WithRSA,  // Only supported for signing, not verification.
+	"sha1_rsa":      x509.SHA1WithRSA, // Only supported for signing, and verification of CRLs, CSRs, and OCSP responses.
+	"sha256_rsa":    x509.SHA256WithRSA,
+	"sha384_rsa":    x509.SHA384WithRSA,
+	"sha512_rsa":    x509.SHA512WithRSA,
+	"sha1_dsa":      x509.DSAWithSHA1,   // Unsupported.
+	"sha256_dsa":    x509.DSAWithSHA256, // Unsupported.
+	"sha1_ecdsa":    x509.ECDSAWithSHA1, // Only supported for signing, and verification of CRLs, CSRs, and OCSP responses.
+	"sha256_ecdsa":  x509.ECDSAWithSHA256,
+	"sha384_ecdsa":  x509.ECDSAWithSHA384,
+	"sha512_ecdsa":  x509.ECDSAWithSHA512,
+	"sha256_rsapss": x509.SHA256WithRSAPSS,
+	"sha384_rsapss": x509.SHA384WithRSAPSS,
+	"sha512_rsapss": x509.SHA512WithRSAPSS,
+	"ed25519":       x509.PureEd25519,
+}
+
+func supportedHashingAlgorithms() []string {
+	list := make([]string, 0, len(keyUsages)+len(signatureAlgorithms))
+
+	for k := range signatureAlgorithms {
+		if strings.Contains(k, "_") {
+			alg := strings.Split(k, "_")[0]
+			list = append(list, alg)
+		}
+	}
+	allKeys := make(map[string]bool)
+	res := []string{}
+	for _, item := range list {
+		if _, value := allKeys[item]; !value {
+			allKeys[item] = true
+			res = append(res, item)
+		}
+	}
+	sort.Strings(res)
+	return res
 }
 
 // supportedKeyUsagesStr returns a slice with all the keys in keyUsages and extendedKeyUsages.
@@ -109,6 +150,39 @@ func generateSubjectKeyID(pubKey crypto.PublicKey) ([]byte, error) {
 
 	pubKeyHash := sha1.Sum(pubKeyBytes)
 	return pubKeyHash[:], nil
+}
+
+// getSignatureAlgorithm calculates the algorithm based on the public key and the desired hash.
+func getSignatureAlgorithm(pubKey crypto.PublicKey, hashAlg string) (*x509.SignatureAlgorithm, error) {
+	var err error
+	var algorithm = hashAlg
+
+	// lookup algorithm from public key type
+	switch pub := pubKey.(type) {
+	case *rsa.PublicKey:
+		algorithm += "_rsa"
+	case *ecdsa.PublicKey:
+		algorithm += "_ecdsa"
+	case ed25519.PublicKey:
+		// no hash algorithm is required
+		algorithm = "ed25519"
+	case *ed25519.PublicKey:
+		// no hash algorithm is required
+		algorithm = "ed25519"
+	default:
+		err = fmt.Errorf("unsupported public key type %T", pub)
+	}
+
+	// If any of the cases above failed, an error would have been set
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal public key of type %T: %w", pubKey, err)
+	}
+
+	if sigAlgo, ok := signatureAlgorithms[algorithm]; ok {
+		return &sigAlgo, nil
+	}
+
+	return nil, fmt.Errorf("unable to determine a signature algorithm from public key of type %T and %s hashing algorithm", pubKey, hashAlg)
 }
 
 func createCertificate(ctx context.Context, template, parent *x509.Certificate, pubKey crypto.PublicKey, prvKey crypto.PrivateKey, plan *tfsdk.Plan) (*commonCertificate, diag.Diagnostics) {
@@ -175,6 +249,24 @@ func createCertificate(ctx context.Context, template, parent *x509.Certificate, 
 		if err != nil {
 			diags.AddError("Failed to generate subject key identifier", err.Error())
 			return nil, diags
+		}
+	}
+
+	// Set signature-algorithm on the template
+	hashAlgorithmPath := path.Root("hashing_algorithm")
+	var hashAlgorithm types.String
+	diags.Append(plan.GetAttribute(ctx, hashAlgorithmPath, &hashAlgorithm)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+	if !hashAlgorithm.IsNull() && !hashAlgorithm.IsUnknown() {
+		var sigAlg, err = getSignatureAlgorithm(pubKey, hashAlgorithm.ValueString())
+		if err != nil {
+			diags.AddError("Failed to generate signature algorithm", err.Error())
+			return nil, diags
+		}
+		if sigAlg != nil {
+			template.SignatureAlgorithm = *sigAlg
 		}
 	}
 

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -44,6 +44,7 @@ type certRequestResourceModel struct {
 	DNSNames       types.List   `tfsdk:"dns_names"`
 	IPAddresses    types.List   `tfsdk:"ip_addresses"`
 	URIs           types.List   `tfsdk:"uris"`
+	HashAlgorithm  types.String `tfsdk:"hashing_algorithm"`
 	PrivateKeyPEM  types.String `tfsdk:"private_key_pem"`
 	KeyAlgorithm   types.String `tfsdk:"key_algorithm"`
 	CertRequestPEM types.String `tfsdk:"cert_request_pem"`
@@ -85,6 +86,7 @@ type selfSignedCertResourceModel struct {
 	Subject             types.List   `tfsdk:"subject"` //< certificateSubjectModel
 	ValidityPeriodHours types.Int64  `tfsdk:"validity_period_hours"`
 	AllowedUses         types.List   `tfsdk:"allowed_uses"`
+	HashAlgorithm       types.String `tfsdk:"hashing_algorithm"`
 	EarlyRenewalHours   types.Int64  `tfsdk:"early_renewal_hours"`
 	IsCACertificate     types.Bool   `tfsdk:"is_ca_certificate"`
 	SetSubjectKeyID     types.Bool   `tfsdk:"set_subject_key_id"`
@@ -103,6 +105,7 @@ type locallySignedCertResourceModel struct {
 	CertRequestPEM      types.String `tfsdk:"cert_request_pem"`
 	ValidityPeriodHours types.Int64  `tfsdk:"validity_period_hours"`
 	AllowedUses         types.List   `tfsdk:"allowed_uses"`
+	HashAlgorithm       types.String `tfsdk:"hashing_algorithm"`
 	EarlyRenewalHours   types.Int64  `tfsdk:"early_renewal_hours"`
 	IsCACertificate     types.Bool   `tfsdk:"is_ca_certificate"`
 	SetSubjectKeyID     types.Bool   `tfsdk:"set_subject_key_id"`

--- a/internal/provider/resource_cert_request_test.go
+++ b/internal/provider/resource_cert_request_test.go
@@ -460,6 +460,68 @@ resource "tls_cert_request" "client_csr" {
 }
 `
 
+const tlsCertRequestWithHash = `
+resource "tls_private_key" "this" {
+	algorithm = "RSA"
+	rsa_bits  = 4096
+}
+
+resource "tls_cert_request" "test" {
+  private_key_pem = tls_private_key.this.private_key_pem
+  hashing_algorithm = "%s"
+
+  subject {
+	common_name = "this"
+  }
+}
+`
+
+func TestResourceCertRequest_PrivateKeyPEMWithHash(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []r.TestStep{
+			{
+				Config: fmt.Sprintf(tlsCertRequestWithHash, "sha512"),
+				Check: r.ComposeAggregateTestCheckFunc(
+					tu.TestCheckPEMCertificateRequestSignatureAlgorithm("tls_cert_request.test", "cert_request_pem", "SHA512-RSA"),
+				),
+			},
+			{
+				Taint:  []string{"tls_cert_request.test"},
+				Config: fmt.Sprintf(tlsCertRequestWithHash, "sha256"),
+				Check: r.ComposeAggregateTestCheckFunc(
+					tu.TestCheckPEMCertificateRequestSignatureAlgorithm("tls_cert_request.test", "cert_request_pem", "SHA256-RSA"),
+				),
+			},
+		},
+	})
+}
+func TestResourceCertRequest_PrivateKeyPEMWithHashIncompatible(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		ProtoV5ProviderFactories: protoV5ProviderFactories(),
+		Steps: []r.TestStep{
+			{
+				Config: `
+				resource "tls_private_key" "this" {
+					algorithm   = "ECDSA"
+					ecdsa_curve = "P384"
+				}
+				
+				resource "tls_cert_request" "test" {
+				  private_key_pem = tls_private_key.this.private_key_pem
+				  hashing_algorithm = "md5"
+				
+				  subject {
+					common_name = "this"
+				  }
+				}
+				`,
+				ExpectError: regexp.MustCompile(`unable to determine a signature algorithm from public key of type`),
+			},
+		},
+	})
+}
+
 func testExtractResourceAttr(resourceName string, attributeName string, attributeValue *string) r.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/internal/provider/resource_locally_signed_cert.go
+++ b/internal/provider/resource_locally_signed_cert.go
@@ -137,6 +137,14 @@ func (r *locallySignedCertResource) Schema(_ context.Context, req resource.Schem
 				Description: "Should the generated certificate include a " +
 					"[subject key identifier](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2) (default: `false`).",
 			},
+			"hashing_algorithm": schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(supportedHashingAlgorithms()...),
+				},
+				Description: "The algorithm to use when hashing the certificate for signature signing " +
+					fmt.Sprintf("Accepted values: `%s`.", strings.Join(supportedHashingAlgorithms(), "`, `")),
+			},
 
 			// Computed attributes
 			"cert_pem": schema.StringAttribute{

--- a/internal/provider/resource_self_signed_cert.go
+++ b/internal/provider/resource_self_signed_cert.go
@@ -170,6 +170,14 @@ func (r *selfSignedCertResource) Schema(_ context.Context, req resource.SchemaRe
 					"for self-signed certificates this is the same value as the " +
 					"[subject key identifier](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2) (default: `false`).",
 			},
+			"hashing_algorithm": schema.StringAttribute{
+				Optional: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(supportedHashingAlgorithms()...),
+				},
+				Description: "The algorithm to use when hashing the certificate for signature signing " +
+					fmt.Sprintf("Accepted values: `%s`.", strings.Join(supportedHashingAlgorithms(), "`, `")),
+			},
 
 			// Computed attributes
 			"cert_pem": schema.StringAttribute{

--- a/internal/provider/testutils/test_check_func.go
+++ b/internal/provider/testutils/test_check_func.go
@@ -196,6 +196,17 @@ func TestCheckPEMCertificateAgainstPEMRootCA(name, key string, rootCA []byte) r.
 	})
 }
 
+func TestCheckPEMCertificateRequestSignatureAlgorithm(name, key string, expected string) r.TestCheckFunc {
+	return TestCheckPEMCertificateRequestWith(name, key, func(crt *x509.CertificateRequest) error {
+		return compareSignatureAlgorithm(expected, &crt.SignatureAlgorithm)
+	})
+}
+func TestCheckPEMCertificateSignatureAlgorithm(name, key string, expected string) r.TestCheckFunc {
+	return TestCheckPEMCertificateWith(name, key, func(crt *x509.Certificate) error {
+		return compareSignatureAlgorithm(expected, &crt.SignatureAlgorithm)
+	})
+}
+
 func compareCertSubjects(expected, actualSubject *pkix.Name) error {
 	if expected.SerialNumber != "" && expected.SerialNumber != actualSubject.SerialNumber {
 		return fmt.Errorf("incorrect subject serial number: expected %v, got %v", expected.SerialNumber, actualSubject.SerialNumber)
@@ -281,6 +292,13 @@ func compareExtKeyUsages(expected, actual []x509.ExtKeyUsage) error {
 		}
 	}
 
+	return nil
+}
+
+func compareSignatureAlgorithm(expected string, actual *x509.SignatureAlgorithm) error {
+	if !cmp.Equal(actual.String(), expected) {
+		return fmt.Errorf("incorrect Signature Algorithm: expected %v, got %v", expected, actual.String())
+	}
 	return nil
 }
 


### PR DESCRIPTION
This PR adds the ability to specify the hashing algorithm that the certificate should use in its signatures.

Rather than specifying the full signature algorithm, we instead specify only the hashing algorithm as we can infer the remainder from the type of certificate supplied. This allows us the flexibility to customize the output without introducing too much complexity for the end user to manage.

This addresses https://github.com/hashicorp/terraform-provider-tls/issues/57