### PR TITLE
datasource/tls_certificate: Use local TLS server and certificate for verify failure testing

### DIFF
--- a/internal/provider/data_source_certificate_test.go
+++ b/internal/provider/data_source_certificate_test.go
@@ -159,9 +159,6 @@ func TestAccDataSourceCertificate_TerraformIO(t *testing.T) {
 	})
 }
 
-// NOTE: Yes, this test is fetching a live certificate.
-// It can potentially break over time, and we will need to keep the
-// data we check against up to date, when that happens.
 func TestAccDataSourceCertificate_BadSSL(t *testing.T) {
 	server, err := tu.NewHTTPServer()
 	if err != nil {

--- a/internal/provider/data_source_certificate_test.go
+++ b/internal/provider/data_source_certificate_test.go
@@ -163,46 +163,33 @@ func TestAccDataSourceCertificate_TerraformIO(t *testing.T) {
 // It can potentially break over time, and we will need to keep the
 // data we check against up to date, when that happens.
 func TestAccDataSourceCertificate_BadSSL(t *testing.T) {
-	r.Test(t, r.TestCase{
+	server, err := tu.NewHTTPServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	go server.ServeTLS()
+
+	r.UnitTest(t, r.TestCase{
 		ProtoV5ProviderFactories: protoV5ProviderFactories(),
 
 		Steps: []r.TestStep{
 			{
-				Config: `
-					data "tls_certificate" "test" {
-						url = "https://untrusted-root.badssl.com/"
-					}
-				`,
+				Config: fmt.Sprintf(`
+						data "tls_certificate" "test" {
+							url = "https://%s"
+						}
+					`, server.Address()),
 				ExpectError: regexp.MustCompile(`(certificate is not trusted|certificate signed by[\s]*unknown[\s]*authority)`),
 			},
 			{
-				Config: `
-					data "tls_certificate" "test" {
-						url = "https://untrusted-root.badssl.com/"
-						verify_chain = false
-					}
-				`,
-				Check: r.ComposeAggregateTestCheckFunc(
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.#", "2"),
-
-					// BadSSL Untrusted Root Certificate Authority
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.issuer", "CN=BadSSL Untrusted Root Certificate Authority,O=BadSSL,L=San Francisco,ST=California,C=US"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.subject", "CN=BadSSL Untrusted Root Certificate Authority,O=BadSSL,L=San Francisco,ST=California,C=US"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.signature_algorithm", "SHA256-RSA"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.public_key_algorithm", "RSA"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.is_ca", "true"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.sha1_fingerprint", "7890c8934d5869b25d2f8d0d646f9a5d7385ba85"),
-
-					// BadSSL
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.issuer", "CN=BadSSL Untrusted Root Certificate Authority,O=BadSSL,L=San Francisco,ST=California,C=US"),
-					r.TestCheckResourceAttrPair("data.tls_certificate.test", "certificates.1.issuer", "data.tls_certificate.test", "certificates.0.subject"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.subject", "CN=*.badssl.com,O=BadSSL,L=San Francisco,ST=California,C=US"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.signature_algorithm", "SHA256-RSA"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.public_key_algorithm", "RSA"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.is_ca", "false"),
-					// MAINTAINER NOTE: This value is expected to change over time.
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.sha1_fingerprint", "6922cd864f3c6299f6e751a019e5ddcdbc415a71"),
-				),
+				Config: fmt.Sprintf(`
+						data "tls_certificate" "test" {
+							url = "https://%s"
+							verify_chain = false
+						}
+					`, server.Address()),
+				Check: localTestCertificateChainCheckFunc(),
 			},
 		},
 	})

--- a/internal/provider/data_source_certificate_test.go
+++ b/internal/provider/data_source_certificate_test.go
@@ -180,7 +180,7 @@ func TestAccDataSourceCertificate_BadSSL(t *testing.T) {
 							url = "https://%s"
 						}
 					`, server.Address()),
-				ExpectError: regexp.MustCompile(`(certificate is not trusted|certificate signed by[\s]*unknown[\s]*authority)`),
+				ExpectError: regexp.MustCompile(`(certificate has expired|certificate is not trusted|certificate signed by[\s]*unknown[\s]*authority)`),
 			},
 			{
 				Config: fmt.Sprintf(`


### PR DESCRIPTION
Closes #516

Previously (likely due to external SSL certificate rotation):

```
=== RUN   TestAccDataSourceCertificate_BadSSL
    data_source_certificate_test.go:166: Step 2/2 error: Check failed: Check 14/14 error: data.tls_certificate.test: Attribute 'certificates.1.sha1_fingerprint' expected "6922cd864f3c6299f6e751a019e5ddcdbc415a71", got "eede8b066561000952c3e599d4873eed75512a3b"
--- FAIL: TestAccDataSourceCertificate_BadSSL (0.64s)
```

The goal of this test is to ensure the data source returns an error if there is an invalid SSL certificate chain, which can be accomplished by running a local TLS server with expired or otherwise invalid SSL certificate.

There still is one external, real-world URL test with `TestAccDataSourceCertificate_TerraformIO`. It seems important to ensure there is one valid URL test for complete coverage though. If that test becomes a regular problem, a local TLS server could potentially be spun up with a valid SSL certificate via Let's Encrypt or something, however that effort is not being prioritized at the moment.