### PR TITLE
all: Bump minimum Go module version to 1.22

### DIFF
--- a/.changes/unreleased/NOTES-20240910-073620.yaml
+++ b/.changes/unreleased/NOTES-20240910-073620.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: 'all: This release introduces no functional changes. It does however include
+  dependency updates which address upstream CVEs.'
+time: 2024-09-10T07:36:20.17731-04:00
+custom:
+  Issue: "552"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,16 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
-    strategy:
-      matrix:
-        go-version: [ '1.21', '1.22' ]
-
     steps:
 
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version-file: 'go.mod'
 
     - name: Run linters
       uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - godot
     - gofmt
     - gosimple
+    - govet
     - ineffassign
     - makezero
     - misspell
@@ -22,7 +23,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - vet
 
 run:
   # Prevent false positive timeouts in CI

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ that return all the details about which version are currently available for a pa
 ## Requirements
 
 * [Terraform](https://www.terraform.io/downloads)
-* [Go](https://go.dev/doc/install) (1.21)
+* [Go](https://go.dev/doc/install) (1.22)
 * [GNU Make](https://www.gnu.org/software/make/)
 * [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) (optional)
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/hashicorp/terraform-provider-tls
 
-go 1.21
-
-toolchain go1.21.3
+go 1.22.7
 
 require (
 	github.com/elazarl/goproxy v0.0.0-20220529153421-8ea89ba92021

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.21
+go 1.22.7
 
 require (
 	github.com/hashicorp/copywrite v0.19.0


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform-providers-devex-internal/issues/182

Bumps the minimum Go module to 1.22.7