### PR TITLE
feat(cert-request): allow_uses, ca_constraint

### DIFF
--- a/docs/resources/cert_request.md
+++ b/docs/resources/cert_request.md
@@ -41,6 +41,8 @@ resource "tls_cert_request" "example" {
 
 ### Optional
 
+- `allowed_uses` (List of String) List of key usages allowed for the issued certificate. Values are defined in [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280) and combine flags defined by both [Key Usages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3) and [Extended Key Usages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12). Accepted values: `any_extended`, `cert_signing`, `client_auth`, `code_signing`, `content_commitment`, `crl_signing`, `data_encipherment`, `decipher_only`, `digital_signature`, `email_protection`, `encipher_only`, `ipsec_end_system`, `ipsec_tunnel`, `ipsec_user`, `key_agreement`, `key_encipherment`, `microsoft_commercial_code_signing`, `microsoft_kernel_code_signing`, `microsoft_server_gated_crypto`, `netscape_server_gated_crypto`, `ocsp_signing`, `server_auth`, `timestamping`.
+- `ca_constraint` (Boolean) Boolean flag to indicate if the CA constraint should be added to the certificate request.
 - `dns_names` (List of String) List of DNS names for which a certificate is being requested (i.e. certificate subjects).
 - `ip_addresses` (List of String) List of IP addresses for which a certificate is being requested (i.e. certificate subjects).
 - `subject` (Block List) The subject for which a certificate is being requested. The acceptable arguments are all optional and their naming is based upon [Issuer Distinguished Names (RFC5280)](https://tools.ietf.org/html/rfc5280#section-4.1.2.4) section. (see [below for nested schema](#nestedblock--subject))

--- a/internal/provider/common_cert.go
+++ b/internal/provider/common_cert.go
@@ -30,6 +30,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
+type BasicConstraints struct {
+	IsCA bool `asn1:"optional"`
+}
+
 var keyUsages = map[string]x509.KeyUsage{
 	"digital_signature":  x509.KeyUsageDigitalSignature,
 	"content_commitment": x509.KeyUsageContentCommitment,
@@ -57,6 +61,35 @@ var extendedKeyUsages = map[string]x509.ExtKeyUsage{
 	"netscape_server_gated_crypto":      x509.ExtKeyUsageNetscapeServerGatedCrypto,
 	"microsoft_commercial_code_signing": x509.ExtKeyUsageMicrosoftCommercialCodeSigning,
 	"microsoft_kernel_code_signing":     x509.ExtKeyUsageMicrosoftKernelCodeSigning,
+}
+
+var keyUsageBits = map[string]int{
+	"digital_signature":  0x80,  // Bit 0
+	"content_commitment": 0x40,  // Bit 1
+	"key_encipherment":   0x20,  // Bit 2
+	"data_encipherment":  0x10,  // Bit 3
+	"key_agreement":      0x08,  // Bit 4
+	"cert_signing":       0x04,  // Bit 5
+	"crl_signing":        0x02,  // Bit 6
+	"encipher_only":      0x01,  // Bit 7 (encipherOnly in first byte)
+	"decipher_only":      0x100, // Bit 8 (decipherOnly in second byte)
+}
+
+var extendedKeyUsageOIDs = map[string]asn1.ObjectIdentifier{
+	"any_extended":                      {2, 5, 29, 37, 0},
+	"server_auth":                       {1, 3, 6, 1, 5, 5, 7, 3, 1},
+	"client_auth":                       {1, 3, 6, 1, 5, 5, 7, 3, 2},
+	"code_signing":                      {1, 3, 6, 1, 5, 5, 7, 3, 3},
+	"email_protection":                  {1, 3, 6, 1, 5, 5, 7, 3, 4},
+	"ipsec_end_system":                  {1, 3, 6, 1, 5, 5, 7, 3, 5},
+	"ipsec_tunnel":                      {1, 3, 6, 1, 5, 5, 7, 3, 6},
+	"ipsec_user":                        {1, 3, 6, 1, 5, 5, 7, 3, 7},
+	"timestamping":                      {1, 3, 6, 1, 5, 5, 7, 3, 8},
+	"ocsp_signing":                      {1, 3, 6, 1, 5, 5, 7, 3, 9},
+	"microsoft_server_gated_crypto":     {1, 3, 6, 1, 4, 1, 311, 10, 3, 3},
+	"netscape_server_gated_crypto":      {2, 16, 840, 1, 113730, 4, 1},
+	"microsoft_commercial_code_signing": {1, 3, 6, 1, 4, 1, 311, 2, 1, 22},
+	"microsoft_kernel_code_signing":     {1, 3, 6, 1, 4, 1, 311, 61, 1, 1},
 }
 
 // supportedKeyUsagesStr returns a slice with all the keys in keyUsages and extendedKeyUsages.

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -50,6 +50,8 @@ type certRequestResourceModel struct {
 	DNSNames       types.List   `tfsdk:"dns_names"`
 	IPAddresses    types.List   `tfsdk:"ip_addresses"`
 	URIs           types.List   `tfsdk:"uris"`
+	AllowedUses    types.List   `tfsdk:"allowed_uses"`
+	CAConstraint   types.Bool   `tfsdk:"ca_constraint"`
 	PrivateKeyPEM  types.String `tfsdk:"private_key_pem"`
 	KeyAlgorithm   types.String `tfsdk:"key_algorithm"`
 	CertRequestPEM types.String `tfsdk:"cert_request_pem"`

--- a/internal/provider/resource_cert_request_test.go
+++ b/internal/provider/resource_cert_request_test.go
@@ -121,6 +121,30 @@ func TestResourceCertRequest(t *testing.T) {
 					tu.TestCheckPEMCertificateRequestURIs("tls_cert_request.test2", "cert_request_pem", []*url.URL{}),
 				),
 			},
+			{
+				Config: `
+						resource "tls_private_key" "test3" {
+								algorithm = "RSA"
+								rsa_bits = 2048
+						}
+						resource "tls_cert_request" "test3" {
+								subject {
+										serial_number = "43"
+								}
+								private_key_pem = tls_private_key.test3.private_key_pem
+								allowed_uses = ["digital_signature", "key_encipherment"]
+								ca_constraint = true
+						}
+				`,
+				Check: r.ComposeAggregateTestCheckFunc(
+					tu.TestCheckPEMFormat("tls_cert_request.test3", "cert_request_pem", PreambleCertificateRequest.String()),
+					tu.TestCheckPEMCertificateRequestSubject("tls_cert_request.test3", "cert_request_pem", &pkix.Name{
+						SerialNumber: "43",
+					}),
+					tu.TestCheckPEMCertificateRequestKeyUsage("tls_cert_request.test3", "cert_request_pem", []string{"digital_signature", "key_encipherment"}),
+					tu.TestCheckPEMCertificateRequestBasicConstraints("tls_cert_request.test3", "cert_request_pem", true),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Related Issue

Fixes #360

## Description

Added the fields `allow_uses` and `ca_constraint` as requested in the linked issue and as discussed in https://github.com/hashicorp/terraform-provider-tls/pull/430

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

no changes
