### PR TITLE
Remove Read-Only Attribute in provider example doc

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,6 @@ resource "tls_private_key" "example" {
 }
 
 resource "tls_self_signed_cert" "example" {
-  key_algorithm   = tls_private_key.example.algorithm
   private_key_pem = tls_private_key.example.private_key_pem
 
   # Certificate expires after 12 hours.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -10,7 +10,6 @@ resource "tls_private_key" "example" {
 }
 
 resource "tls_self_signed_cert" "example" {
-  key_algorithm   = tls_private_key.example.algorithm
   private_key_pem = tls_private_key.example.private_key_pem
 
   # Certificate expires after 12 hours.


### PR DESCRIPTION
## Related Issue

Remove key_algorithm (Read-Only Attribute) in provider example doc

## Description

When running example provided in the provider example, it has the error.

```
Error: Invalid Configuration for Read-Only Attribute
│
│   with tls_self_signed_cert.example,
│   on main.tf line 15, in resource "tls_self_signed_cert" "example":
│   15:   key_algorithm = tls_private_key.example.algorithm
│
│ Cannot set value for this attribute as the provider has marked it as read-only. Remove the configuration line setting the value.
│
│ Refer to the provider documentation or contact the provider developers for additional information about configurable and read-only attributes that are
│ supported.
```



<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
