### PR TITLE
Update SHA1 fingerprint for live cert test

### DIFF
--- a/internal/provider/data_source_certificate_test.go
+++ b/internal/provider/data_source_certificate_test.go
@@ -119,7 +119,7 @@ func TestAccDataSourceCertificate_UpgradeFromVersion3_4_0(t *testing.T) {
 }
 
 // NOTE: Yes, this test is fetching a live certificate.
-// It can potentially break over time, and we will need to keep the
+// It will break over time and we will need to keep the
 // data we check against up to date, when that happens.
 func TestAccDataSourceCertificate_DevDot(t *testing.T) {
 	r.Test(t, r.TestCase{
@@ -137,11 +137,11 @@ func TestAccDataSourceCertificate_DevDot(t *testing.T) {
 
 					// ISRG Root X1
 					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.issuer", "CN=ISRG Root X1,O=Internet Security Research Group,C=US"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.subject", "CN=R11,O=Let's Encrypt,C=US"),
+					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.subject", "CN=R10,O=Let's Encrypt,C=US"),
 					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.signature_algorithm", "SHA256-RSA"),
 					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.public_key_algorithm", "RSA"),
 					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.is_ca", "true"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.sha1_fingerprint", "696db3af0dffc17e65c6a20d925c5a7bd24dec7e"),
+					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.sha1_fingerprint", "00abefd055f9a9c784ffdeabd1dcdd8fed741436"),
 
 					// developer.hashicorp.com
 					r.TestCheckResourceAttrPair("data.tls_certificate.test", "certificates.1.issuer", "data.tls_certificate.test", "certificates.0.subject"),


### PR DESCRIPTION
## Related Issue

https://github.com/hashicorp/terraform-provider-tls/pull/348

## Description

It's about that time to update the live TLS test  🕐 

Similar to https://github.com/hashicorp/terraform-provider-tls/pull/348, this test changes over time and we know that. I updated the comment since it suggests a world where this test doesn't need to be updated 😆 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No
