### PR TITLE
Adds support for write only CA private key on tls_locally_signed_cert

### DIFF
--- a/docs/resources/locally_signed_cert.md
+++ b/docs/resources/locally_signed_cert.md
@@ -38,12 +38,16 @@ resource "tls_locally_signed_cert" "example" {
 
 - `allowed_uses` (List of String) List of key usages allowed for the issued certificate. Values are defined in [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280) and combine flags defined by both [Key Usages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3) and [Extended Key Usages](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.12). Accepted values: `any_extended`, `cert_signing`, `client_auth`, `code_signing`, `content_commitment`, `crl_signing`, `data_encipherment`, `decipher_only`, `digital_signature`, `email_protection`, `encipher_only`, `ipsec_end_system`, `ipsec_tunnel`, `ipsec_user`, `key_agreement`, `key_encipherment`, `microsoft_commercial_code_signing`, `microsoft_kernel_code_signing`, `microsoft_server_gated_crypto`, `netscape_server_gated_crypto`, `ocsp_signing`, `server_auth`, `timestamping`.
 - `ca_cert_pem` (String) Certificate data of the Certificate Authority (CA) in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format.
-- `ca_private_key_pem` (String, Sensitive) Private key of the Certificate Authority (CA) used to sign the certificate, in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format.
 - `cert_request_pem` (String) Certificate request data in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format.
 - `validity_period_hours` (Number) Number of hours, after initial issuing, that the certificate will remain valid for.
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
+- `ca_private_key_pem` (String, Sensitive) Private key of the Certificate Authority (CA) used to sign the certificate, in [PEM (RFC 1421)](https://datatracker.ietf.org/doc/html/rfc1421) format. Either ca_private_key_pem or ca_private_key_pem_wo must be provided.
+- `ca_private_key_pem_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Write only variant of private_key_pem. Either ca_private_key_pem_wo or ca_private_key_pem must be provided.
+- `ca_private_key_pem_wo_version` (Number) Triggers update of the certificate using the ca_private_key_pem_wo write-only value.
 - `early_renewal_hours` (Number) The resource will consider the certificate to have expired the given number of hours before its actual expiry time. This can be useful to deploy an updated certificate in advance of the expiration of the current certificate. However, the old certificate remains valid until its true expiration time, since this resource does not (and cannot) support certificate revocation. Also, this advance update can only be performed should the Terraform configuration be applied during the early renewal period. (default: `0`)
 - `is_ca_certificate` (Boolean) Is the generated certificate representing a Certificate Authority (CA) (default: `false`).
 - `set_subject_key_id` (Boolean) Should the generated certificate include a [subject key identifier](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.2) (default: `false`).

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -204,18 +204,20 @@ type selfSignedCertResourceModel struct {
 }
 
 type locallySignedCertResourceModel struct {
-	CACertPEM           types.String `tfsdk:"ca_cert_pem"`
-	CAPrivateKeyPEM     types.String `tfsdk:"ca_private_key_pem"`
-	CertRequestPEM      types.String `tfsdk:"cert_request_pem"`
-	ValidityPeriodHours types.Int64  `tfsdk:"validity_period_hours"`
-	AllowedUses         types.List   `tfsdk:"allowed_uses"`
-	EarlyRenewalHours   types.Int64  `tfsdk:"early_renewal_hours"`
-	IsCACertificate     types.Bool   `tfsdk:"is_ca_certificate"`
-	SetSubjectKeyID     types.Bool   `tfsdk:"set_subject_key_id"`
-	CertPEM             types.String `tfsdk:"cert_pem"`
-	ReadyForRenewal     types.Bool   `tfsdk:"ready_for_renewal"`
-	ValidityStartTime   types.String `tfsdk:"validity_start_time"`
-	ValidityEndTime     types.String `tfsdk:"validity_end_time"`
-	CAKeyAlgorithm      types.String `tfsdk:"ca_key_algorithm"`
-	ID                  types.String `tfsdk:"id"`
+	CACertPEM                types.String `tfsdk:"ca_cert_pem"`
+	CAPrivateKeyPEM          types.String `tfsdk:"ca_private_key_pem"`
+	CAPrivateKeyPEMWO        types.String `tfsdk:"ca_private_key_pem_wo"`
+	CAPrivateKeyPEMWOVersion types.Int64  `tfsdk:"ca_private_key_pem_wo_version"`
+	CertRequestPEM           types.String `tfsdk:"cert_request_pem"`
+	ValidityPeriodHours      types.Int64  `tfsdk:"validity_period_hours"`
+	AllowedUses              types.List   `tfsdk:"allowed_uses"`
+	EarlyRenewalHours        types.Int64  `tfsdk:"early_renewal_hours"`
+	IsCACertificate          types.Bool   `tfsdk:"is_ca_certificate"`
+	SetSubjectKeyID          types.Bool   `tfsdk:"set_subject_key_id"`
+	CertPEM                  types.String `tfsdk:"cert_pem"`
+	ReadyForRenewal          types.Bool   `tfsdk:"ready_for_renewal"`
+	ValidityStartTime        types.String `tfsdk:"validity_start_time"`
+	ValidityEndTime          types.String `tfsdk:"validity_end_time"`
+	CAKeyAlgorithm           types.String `tfsdk:"ca_key_algorithm"`
+	ID                       types.String `tfsdk:"id"`
 }


### PR DESCRIPTION
## Related Issue

Contributes to https://github.com/hashicorp/terraform-provider-tls/issues/645

## Description

Adds support for write only for the CA private key on tls_locally_signed_cert as described in https://developer.hashicorp.com/terraform/plugin/framework/resources/write-only-arguments

Adds the write only properties as an alternative for private_key_pem.

- ca_private_key_pem_wo
- ca_private_key_pem_wo_version

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
