### PR TITLE
enhancement: force HTTP/2 when fetching peer certificates via HTTPS

### DIFF
--- a/internal/provider/data_source_certificate.go
+++ b/internal/provider/data_source_certificate.go
@@ -237,6 +237,7 @@ func fetchPeerCertificatesViaHTTPS(ctx context.Context, targetURL *url.URL, shou
 
 	client := &http.Client{
 		Transport: &http.Transport{
+			ForceAttemptHTTP2: true,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: !shouldVerifyChain,
 			},


### PR DESCRIPTION
## Related Issue

Fixes # <!-- INSERT ISSUE NUMBER -->

## Description

Added `ForceAttemptHTTP2: true` to the `http.Transport` in the `fetchPeerCertificatesViaHTTPS` function. This ensures that when the `tls_certificate` data source fetches peer certificates over HTTPS, it will prefer HTTP/2 connections where the server supports it, improving connection efficiency.

The change is minimal and targeted: it sets the `ForceAttemptHTTP2` field on the existing transport struct alongside the existing `TLSClientConfig` and `Proxy` fields.

> **Note:** A changelog entry via Changie should be added once a PR/issue number is assigned:
> ```
> data-source/tls_certificate: Force HTTP/2 connection attempts when fetching certificates via HTTPS
> ```

## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls. `ForceAttemptHTTP2` only affects the HTTP protocol version negotiated; the existing `TLSClientConfig` (including `InsecureSkipVerify`) and proxy settings are unchanged.