### PR TITLE
Replace deprecated ECDSA public key marshal

### DIFF
--- a/internal/provider/common_cert.go
+++ b/internal/provider/common_cert.go
@@ -8,7 +8,6 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
-	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -88,8 +87,7 @@ func generateSubjectKeyID(pubKey crypto.PublicKey) ([]byte, error) {
 			err = fmt.Errorf("received 'nil' pointer instead of public key")
 		}
 	case *ecdsa.PublicKey:
-		//nolint:staticcheck // Reference: https://github.com/hashicorp/terraform-provider-tls/issues/480
-		pubKeyBytes = elliptic.Marshal(pub.Curve, pub.X, pub.Y)
+		pubKeyBytes, err = marshalECDSAPublicKey(pub)
 	case ed25519.PublicKey:
 		pubKeyBytes, err = asn1.Marshal(pub)
 	case *ed25519.PublicKey:
@@ -109,6 +107,27 @@ func generateSubjectKeyID(pubKey crypto.PublicKey) ([]byte, error) {
 
 	pubKeyHash := sha1.Sum(pubKeyBytes)
 	return pubKeyHash[:], nil
+}
+
+func marshalECDSAPublicKey(pub *ecdsa.PublicKey) ([]byte, error) {
+	if pub == nil {
+		return nil, fmt.Errorf("received 'nil' pointer instead of public key")
+	}
+
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
+
+	var spki struct {
+		Algorithm        pkix.AlgorithmIdentifier
+		SubjectPublicKey asn1.BitString
+	}
+	if _, err := asn1.Unmarshal(der, &spki); err != nil {
+		return nil, err
+	}
+
+	return spki.SubjectPublicKey.Bytes, nil
 }
 
 func createCertificate(ctx context.Context, template, parent *x509.Certificate, pubKey crypto.PublicKey, prvKey crypto.PrivateKey, plan *tfsdk.Plan) (*commonCertificate, diag.Diagnostics) {

--- a/internal/provider/common_cert_test.go
+++ b/internal/provider/common_cert_test.go
@@ -1,0 +1,63 @@
+// Copyright IBM Corp. 2017, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha1"
+	"testing"
+)
+
+func TestGenerateSubjectKeyID_ECDSA(t *testing.T) {
+	testCases := []struct {
+		name  string
+		curve elliptic.Curve
+	}{
+		{name: "P224", curve: elliptic.P224()},
+		{name: "P256", curve: elliptic.P256()},
+		{name: "P384", curve: elliptic.P384()},
+		{name: "P521", curve: elliptic.P521()},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			key, err := ecdsa.GenerateKey(tc.curve, rand.Reader)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actual, err := generateSubjectKeyID(&key.PublicKey)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expected := sha1.Sum(uncompressedECDSAPublicKeyBytes(t, &key.PublicKey))
+			if !bytes.Equal(actual, expected[:]) {
+				t.Fatalf("unexpected subject key ID\nexpected: %x\nactual:   %x", expected, actual)
+			}
+		})
+	}
+}
+
+func TestGenerateSubjectKeyID_nilECDSAPublicKey(t *testing.T) {
+	_, err := generateSubjectKeyID((*ecdsa.PublicKey)(nil))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func uncompressedECDSAPublicKeyBytes(t *testing.T, pub *ecdsa.PublicKey) []byte {
+	t.Helper()
+
+	byteLen := (pub.Curve.Params().BitSize + 7) / 8
+	result := make([]byte, 1+2*byteLen)
+	result[0] = 4
+	pub.X.FillBytes(result[1 : 1+byteLen])
+	pub.Y.FillBytes(result[1+byteLen:])
+
+	return result
+}


### PR DESCRIPTION
## Summary
- Replace the deprecated ECDSA subject-key-id marshal path with SPKI SubjectPublicKey extraction.
- Preserve the same uncompressed point bytes used for the subject key identifier, including P-224 keys.
- Add unit coverage for all supported ECDSA curves and typed nil ECDSA public keys.

Closes #480

## Testing
- go test ./internal/provider -run "TestGenerateSubjectKeyID"
- go test ./...