### PR TITLE
tests: update DevDot cert chain assertions to match current chain

### DIFF
--- a/.changes/unreleased/NOTES-20260716-162605.yaml
+++ b/.changes/unreleased/NOTES-20260716-162605.yaml
@@ -1,4 +1,4 @@
-kind: NOTES
+kind: ENHANCEMENTS
 body: Updated `TestAccDataSourceCertificate_DevDot` acceptance test to reflect the current TLS certificate chain for `developer.hashicorp.com`
 time: 2026-07-16T16:26:05.622161-04:00
 custom:

--- a/.changes/unreleased/NOTES-20260716-162605.yaml
+++ b/.changes/unreleased/NOTES-20260716-162605.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: Updated `TestAccDataSourceCertificate_DevDot` acceptance test to reflect the current TLS certificate chain for `developer.hashicorp.com`
+time: 2026-07-16T16:26:05.622161-04:00
+custom:
+    Issue: "793"

--- a/internal/provider/data_source_certificate_test.go
+++ b/internal/provider/data_source_certificate_test.go
@@ -123,7 +123,7 @@ func TestAccDataSourceCertificate_UpgradeFromVersion3_4_0(t *testing.T) {
 // NOTE: Yes, this test is fetching a live certificate.
 // It will break over time and we will need to keep the
 // data we check against up to date, when that happens.
-// Last updated: 2025-07-02
+// Last updated: 2025-07-02.
 func TestAccDataSourceCertificate_DevDot(t *testing.T) {
 	r.Test(t, r.TestCase{
 		ProtoV5ProviderFactories: protoV5ProviderFactories(),

--- a/internal/provider/data_source_certificate_test.go
+++ b/internal/provider/data_source_certificate_test.go
@@ -123,6 +123,7 @@ func TestAccDataSourceCertificate_UpgradeFromVersion3_4_0(t *testing.T) {
 // NOTE: Yes, this test is fetching a live certificate.
 // It will break over time and we will need to keep the
 // data we check against up to date, when that happens.
+// Last updated: 2025-07-02
 func TestAccDataSourceCertificate_DevDot(t *testing.T) {
 	r.Test(t, r.TestCase{
 		ProtoV5ProviderFactories: protoV5ProviderFactories(),
@@ -135,26 +136,32 @@ func TestAccDataSourceCertificate_DevDot(t *testing.T) {
 					}
 				`,
 				Check: r.ComposeAggregateTestCheckFunc(
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.#", "2"),
+					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.#", "3"),
 
-					// ISRG Root X1
+					// Root YR (ISRG root)
+					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.subject", "CN=Root YR,O=ISRG,C=US"),
 					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.issuer", "CN=ISRG Root X1,O=Internet Security Research Group,C=US"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.subject", "CN=R13,O=Let's Encrypt,C=US"),
 					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.signature_algorithm", "SHA256-RSA"),
 					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.public_key_algorithm", "RSA"),
 					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.is_ca", "true"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.max_path_length", "0"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.sha1_fingerprint", "22ff89586561fc2d52f77491e9f1eff1b80be33e"),
+					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.0.sha1_fingerprint", "ab9d0263244dd0326eb67015705a667e79cfe998"),
 
-					// developer.hashicorp.com
+					// YR2 (Let's Encrypt intermediate)
 					r.TestCheckResourceAttrPair("data.tls_certificate.test", "certificates.1.issuer", "data.tls_certificate.test", "certificates.0.subject"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.subject", "CN=developer.hashicorp.com"),
+					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.subject", "CN=YR2,O=Let's Encrypt,C=US"),
 					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.signature_algorithm", "SHA256-RSA"),
 					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.public_key_algorithm", "RSA"),
-					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.is_ca", "false"),
+					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.is_ca", "true"),
+					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.1.max_path_length", "0"),
+					// NOTE: Not checking the fingerprint, as this certificate is auto-updated frequently.
 
-					// NOTE: Not checking the fingerprint, as this certificate is auto-updated frequently:
-					//   all the other data are stable, but the signature changes every time.
+					// developer.hashicorp.com (leaf)
+					r.TestCheckResourceAttrPair("data.tls_certificate.test", "certificates.2.issuer", "data.tls_certificate.test", "certificates.1.subject"),
+					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.2.subject", "CN=developer.hashicorp.com"),
+					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.2.signature_algorithm", "SHA256-RSA"),
+					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.2.public_key_algorithm", "RSA"),
+					r.TestCheckResourceAttr("data.tls_certificate.test", "certificates.2.is_ca", "false"),
+					// NOTE: Not checking the fingerprint, as this certificate is auto-updated frequently.
 				),
 			},
 		},


### PR DESCRIPTION
## Related Issue

Fixes CI errors for PR #789 

## Description
The `TestAccDataSourceCertificate_DevDot` test fetches the live TLS cert chain for `developer.hashicorp.com` and asserts against hardcoded values. The chain has rotated — it now returns 3 certs instead of 2, with a new ISRG root (`CN=Root YR`) and a new Let's Encrypt intermediate (`CN=YR2`).

This updates the assertions to match the current chain. As noted in the existing comment, this is expected maintenance.

Changes:
- `certificates.#` updated from `2` to `3`
- `certificates.0` now describes `CN=Root YR` (ISRG root)
- `certificates.1` now describes `CN=YR2` (Let's Encrypt intermediate)
- `certificates.2` now describes `CN=developer.hashicorp.com` (leaf)
- Fingerprints are not asserted on the intermediate or leaf (both rotate frequently)

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
No